### PR TITLE
LLT-5652 Performance measurements

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
-[target.'cfg(unix)']
-runner = 'sudo -E'
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
       )
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: CI Trigger
       run: echo "Triggering CI"
@@ -27,7 +27,7 @@ jobs:
     needs:
     - linters
     - tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Collect statuses from all jobs
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -4,7 +4,7 @@ permissions: {}
 
 jobs:
   rustfmt:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.3
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-22.04
+        - os: ubuntu-24.04
           packages: ""
-        - os: macos-12
+        - os: macos-14
           packages: ""
         - os: windows-2022
           packages: "-p neptun"
@@ -33,9 +33,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-22.04
+        - os: ubuntu-24.04
           packages: ""
-        - os: macos-12
+        - os: macos-14
           packages: ""
         - os: windows-2022
           packages: -p neptun
@@ -60,7 +60,7 @@ jobs:
         args: '--workspace --locked --output human --backend depinfo'
 
   deny:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - uses: EmbarkStudios/cargo-deny-action@8371184bd11e21dcf8ac82ebf8c9c9f74ebf7268 # v2.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,9 @@ jobs:
     strategy:
         matrix:
           include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             packages: ""
-          - os: macos-12
+          - os: macos-14
             packages: ""
           - os: windows-2022
             packages: -p neptun
@@ -24,19 +24,28 @@ jobs:
   integration-tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-24.04, macos-14 ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
-    - run: cargo test -- --ignored
+    - run: CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo test -- --ignored
 
   crypto-bench:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-24.04, macos-14, windows-2022 ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
     - run: cargo bench -p neptun --no-run
+
+  performance-tests:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      with:
+        fetch-depth: 0
+    - run: docker build -t neptun-runner:0.0.1 .
+    - run: cargo xtask perf --base main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -268,6 +275,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -493,6 +512,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1519,6 +1544,30 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core",
+]
+
+[[package]]
+name = "xshell"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7290c623014758632efe00737145b6867b66292c42167f2ec381eb566a373d"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "xshell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["neptun", "neptun-cli"]
+members = ["neptun", "neptun-cli", "xtask"]
 
 [profile.release]
 lto = true        # Enable full link-time optimization.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  iperf3 \
+  iproute2 \
+  iputils-ping \
+  net-tools \
+  wireguard-go \
+  wireguard-tools \
+  && rm -rf /var/lib/apt/lists/*

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask"
+license = "BSD-3-Clause"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+xshell = "0.2.7"

--- a/xtask/perf/docker-compose.yml
+++ b/xtask/perf/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.2'
+
+services:
+  left:
+    hostname: left
+    container_name: left
+    image: neptun-runner:0.0.1
+    entrypoint: /neptun/config/left.sh
+    privileged: true
+    depends_on:
+      right:
+        condition: service_healthy
+    networks:
+      default:
+        ipv4_address: 176.0.0.2
+    volumes:
+      - ../../target/release:/neptun/current
+      - ../../base/target/release:/neptun/base
+      - .:/neptun/config
+
+  right:
+    hostname: right
+    container_name: right
+    image: neptun-runner:0.0.1
+    entrypoint: /neptun/config/right.sh
+    privileged: true
+    healthcheck:
+      test: ["CMD-SHELL", "cat /.iperf_ready"]
+      interval: 1s
+      start_interval: 1s
+      start_period: 60s
+    networks:
+      default:
+        ipv4_address: 176.0.0.3
+    volumes:
+      - ../../target/release:/neptun/current
+      - ../../base/target/release:/neptun/base
+      - .:/neptun/config
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 176.0.0.0/24

--- a/xtask/perf/left.sh
+++ b/xtask/perf/left.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+wireguard-go wg0
+wg set wg0 \
+    listen-port 51820 \
+    private-key <(echo AH7jKt6M0RS21MkRG+URrfgmwvJqdhVvqtKeF4WR+E8=) \
+    peer mqrc8+LD+6zvMeCtyCcIBPEYuXT74lq1Hros0Np8ZgA= \
+    allowed-ips 10.0.0.2/32 \
+    endpoint 176.0.0.3:51820
+ip address add dev wg0 10.0.0.1/24
+ip link set up dev wg0
+
+/neptun/base/neptun-cli --disable-drop-privileges wg1
+wg set wg1 \
+    listen-port 51821 \
+    private-key <(echo sKZoT3qgxDm1bWny+1ttoi00qS2KXvo1L4Zb265wr3c=) \
+    peer CMWokCGH+YPN7CL2C2aAkDlnhw1blH0tKPOnEOgzrxM= \
+    allowed-ips 10.0.1.2/32 \
+    endpoint 176.0.0.3:51821
+ip address add dev wg1 10.0.1.1/24
+ip link set up dev wg1
+
+/neptun/current/neptun-cli --disable-drop-privileges wg2
+wg set wg2 \
+    listen-port 51822 \
+    private-key <(echo 0Fn5JWI1QGDiaVYLDBSLklIEBUujfpX1oH/UGI2D62k=) \
+    peer fqrU1Wk8nuyy6phf8IUDwcKK1ElslFYDyteANr2hlgM= \
+    allowed-ips 10.0.2.2/32 \
+    endpoint 176.0.0.3:51822
+ip address add dev wg2 10.0.2.1/24
+ip link set up dev wg2
+
+echo
+echo "Raw network:"
+iperf3 -i 10 -t  10 --bidir -c 176.0.0.3
+
+echo
+echo "Wireguard-go:"
+iperf3 -i 60 -t 120 --bidir -c 10.0.0.2
+
+echo
+echo "Base NepTUN:"
+iperf3 -i 60 -t 120 --bidir -c 10.0.1.2
+
+echo
+echo "Current NepTUN:"
+iperf3 -i 60 -t 120 --bidir -c 10.0.2.2

--- a/xtask/perf/right.sh
+++ b/xtask/perf/right.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+wireguard-go wg0
+wg set wg0 \
+    listen-port 51820 \
+    private-key <(echo MLBFYI9O69v8WdVodp4YucqnvW+onpD/R5kF/GE18F8=) \
+    peer 7gr2QZyPpaIdlsPcZcQozgpjDdCkefZtxz12Dmpj/3Y= \
+    allowed-ips 10.0.0.1/32 \
+    endpoint 176.0.0.2:51820
+ip address add dev wg0 10.0.0.2/24
+ip link set up dev wg0
+
+/neptun/base/neptun-cli --disable-drop-privileges wg1
+wg set wg1 \
+    listen-port 51821 \
+    private-key <(echo WAoFbPJ6QaXXltwLqBADFkMG6qLZuivSlkIUv2Sc3lY=) \
+    peer HcDZRTIcI3Yok4XTwhAScKoNkb9MIZ2wyjS1oQvZnic= \
+    allowed-ips 10.0.1.1/32 \
+    endpoint 176.0.0.2:51821
+ip address add dev wg1 10.0.1.2/24
+ip link set up dev wg1
+
+/neptun/current/neptun-cli --disable-drop-privileges wg2
+wg set wg2 \
+    listen-port 51822 \
+    private-key <(echo eNOePaXKpyN9IjNEDe1a4CzBAwdbLupbF5wfdCUjS18=) \
+    peer zj6KZHkVw3ILScBGgUaYfuRkwhK6GgrIHmzfd4MPx1k= \
+    allowed-ips 10.0.2.1/32 \
+    endpoint 176.0.0.2:51822
+ip address add dev wg2 10.0.2.2/24
+ip link set up dev wg2
+
+iperf3 -s > /dev/null &
+touch /.iperf_ready
+sleep infinity

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,15 @@
+mod perf;
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+enum Cmd {
+    /// Run performance benchmark
+    Perf(perf::Cmd),
+}
+
+fn main() {
+    match Cmd::parse() {
+        Cmd::Perf(perf) => perf.run(),
+    }
+}

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+use clap::Parser;
+use xshell::{cmd, Shell};
+
+#[derive(Parser, Debug)]
+pub struct Cmd {
+    /// Git ref of the benchmark base
+    #[arg(short, long)]
+    base: String,
+}
+
+struct GitWorktree {
+    name: String,
+    sh: Shell,
+}
+
+impl GitWorktree {
+    fn new(name: &str, base_ref: &str) -> Self {
+        let sh = Shell::new().expect("Failed to create shell object");
+        cmd!(sh, "git worktree add {name} {base_ref}")
+            .run()
+            .expect("Failed to create base worktree");
+        GitWorktree {
+            name: name.to_string(),
+            sh: sh,
+        }
+    }
+}
+
+impl Drop for GitWorktree {
+    fn drop(&mut self) {
+        let name = &self.name;
+        _ = cmd!(self.sh, "git worktree remove {name}").run();
+    }
+}
+
+fn build_neptun_cli(dir: &str) {
+    let sh = Shell::new().expect("Failed to create shell object");
+    sh.change_dir(dir);
+    cmd!(sh, "cargo build --release -p neptun-cli")
+        .run()
+        .expect("Failed to build base version");
+}
+
+impl Cmd {
+    pub fn run(&self) {
+        let worktree = GitWorktree::new("base", &self.base);
+        build_neptun_cli(".");
+        build_neptun_cli(&worktree.name);
+
+        let sh = Shell::new().expect("Failed to create shell object");
+        cmd!(
+            sh,
+            "docker compose -f xtask/perf/docker-compose.yml up --abort-on-container-exit"
+        )
+        .run()
+        .expect("Failed to build base version");
+    }
+}


### PR DESCRIPTION
First version of performance measurement rig

Runs iperf3 via wireguard-go, main branch of NepTUN and the current
branch between two docker containers. The results are printed in the
job log. Probably we want to add some configurability to those scripts
but it is better to do it as we go, when we actually know what we need.

Most likely we want those improvements:
- host docker image and make automation for its update