### PR TITLE
Fix comment.

### DIFF
--- a/neptun/src/sleepyinstant/mod.rs
+++ b/neptun/src/sleepyinstant/mod.rs
@@ -49,10 +49,6 @@ impl Instant {
 
     /// Returns the amount of time elapsed from another instant to this one,
     /// or zero duration if that instant is later than this one.
-    ///
-    /// # Panics
-    ///
-    /// panics when `earlier` was later than `self`.
     pub fn duration_since(&self, earlier: Instant) -> Duration {
         self.t.duration_since(earlier.t)
     }


### PR DESCRIPTION
The underlying method saturates. This comment was likely written with an old underlying implementation.

---

I was reading over the code to check for possible panics in Duration arithmetic and noticed this inconsistency in the comment. I may have misunderstood something but it seems that this just calls a method which saturates.

https://github.com/NordSecurity/NepTUN/blob/6d6e95e3459a40b669cc45e35c96a4f31fc7ead6/neptun/src/sleepyinstant/unix.rs#L44