### PR TITLE
Add pcap analysis to XRay

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+    - if: matrix.os == 'ubuntu-24.04'
+      run: sudo apt-get install -y libpcap-dev
     - name: Install hack
       run: cargo +stable install --git https://github.com/taiki-e/cargo-hack.git cargo-hack --rev c0b517b9eefa27cdaf27cca5f1b186c00ef1af47 --locked
     - run: cargo hack test --each-feature ${{ matrix.packages }}
@@ -29,6 +31,8 @@ jobs:
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+    - if: matrix.os == 'ubuntu-24.04'
+      run: sudo apt-get install -y libpcap-dev
     - run: CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo test -- --ignored
 
   crypto-bench:
@@ -59,7 +63,7 @@ jobs:
         working-directory: xray
         run: |
           sudo apt update
-          sudo apt install -y wireguard wireguard-go
+          sudo apt install -y wireguard wireguard-go libpcap-dev
           python -m pip install --upgrade pip
           pip install pipenv
           pipenv install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
@@ -511,6 +517,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "etherparse"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +738,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,7 +845,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -908,10 +945,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcap"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "499125886165f62fbc0c095ead9189b253f48eb1c5fcab49f81a270f2f220652"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "libc",
+ "libloading",
+ "pkg-config",
+ "regex",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
@@ -1132,7 +1190,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1649,6 +1707,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -1672,13 +1743,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1689,9 +1760,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1707,9 +1790,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1722,6 +1817,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1751,8 +1852,10 @@ dependencies = [
  "csv",
  "curve25519-dalek",
  "neptun",
+ "pcap",
  "pnet",
  "rand",
+ "serde",
  "thiserror",
  "tokio",
  "x25519-dalek",

--- a/neptun/Cargo.toml
+++ b/neptun/Cargo.toml
@@ -15,6 +15,7 @@ default = []
 device = ["socket2", "thiserror"]
 # mocks std::time::Instant with mock_instant
 mock-instant = ["mock_instant"]
+xray = []
 
 [dependencies]
 base64 = "0.13"

--- a/xray/Cargo.toml
+++ b/xray/Cargo.toml
@@ -11,8 +11,10 @@ clap = { version = "4.5", features = ["derive"] }
 color-eyre = "0.6"
 csv = "1.3.1"
 curve25519-dalek = "4.1"
+pcap = "2.2"
 pnet = "0.35"
 rand = "0.8.5"
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.41", features = ["macros", "rt-multi-thread", "time", "net", "sync"] }
 x25519-dalek = "2.0"
@@ -20,4 +22,4 @@ x25519-dalek = "2.0"
 [dependencies.neptun]
 version = "0.6.0"
 path = "../neptun"
-features = ["device"]
+features = ["device", "xray"]

--- a/xray/Pipfile
+++ b/xray/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 ruff = "==0.8"
 matplotlib = "==3.9"
-scapy = "==2.6"
 mpl_ascii = "==0.10"
 
 [dev-packages]

--- a/xray/src/client.rs
+++ b/xray/src/client.rs
@@ -195,6 +195,7 @@ impl Client {
                     ret = RecvType::Data {
                         length: payload_end - payload_start,
                     };
+                    bytes_read = 0;
                 }
                 unexpected => return Err(XRayError::from(unexpected)),
             }
@@ -240,7 +241,7 @@ impl Client {
         Ok(udp_packet)
     }
 
-    fn parse_udp_packet(packet: &[u8]) -> XRayResult<(SocketAddrV4, usize, usize)> {
+    pub fn parse_udp_packet(packet: &[u8]) -> XRayResult<(SocketAddrV4, usize, usize)> {
         let ip_packet = Ipv4Packet::new(packet).ok_or(XRayError::PacketParse)?;
         let udp_packet = UdpPacket::new(ip_packet.payload()).ok_or(XRayError::PacketParse)?;
         let from = SocketAddrV4::new(ip_packet.get_source(), udp_packet.get_source());

--- a/xray/src/key_pair.rs
+++ b/xray/src/key_pair.rs
@@ -30,8 +30,8 @@ pub trait NepTUNKey {
         BASE64_STANDARD.encode(self.bytes())
     }
 
-    fn write_to_file(&self, file_name: &str) -> XRayResult<()> {
-        let mut f = File::create(file_name)?;
+    fn write_to_file(&self, path: &str) -> XRayResult<()> {
+        let mut f = File::create(path)?;
         f.write_all(self.as_b64().as_bytes())?;
         Ok(())
     }

--- a/xray/src/main.rs
+++ b/xray/src/main.rs
@@ -1,6 +1,7 @@
 mod client;
 mod event_loop;
 mod key_pair;
+mod pcap;
 mod utils;
 
 use std::{
@@ -10,8 +11,10 @@ use std::{
 
 use neptun::noise::{Tunn, TunnResult};
 
+use ::pcap::Error as PcapError;
 use clap::Parser;
 use color_eyre::eyre::Result as EyreResult;
+
 use tokio::{
     net::UdpSocket,
     sync::mpsc::{self, error::SendError},
@@ -21,15 +24,20 @@ use crate::{
     client::Client,
     event_loop::EventLoop,
     key_pair::KeyPair,
-    utils::{configure_wg, TestCmd},
+    pcap::process_pcap,
+    utils::{configure_wg, run_command, write_to_csv, TestCmd},
 };
 
 const WG_NAME: &str = "xraywg1";
 
-const WG_ADDR: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new(100, 66, 0, 1), 41414);
-const PLAINTEXT_ADDR: SocketAddrV4 = SocketAddrV4::new(*WG_ADDR.ip(), 52525);
-const CRYPTO_ADDR: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new(100, 66, 0, 2), 63636);
-const CRYPTO_SOCK_ADDR: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 63636);
+const WG_PORT: u16 = 41414;
+const PLAINTEXT_PORT: u16 = 52525;
+const CRYPTO_PORT: u16 = 63636;
+
+const WG_ADDR: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new(100, 66, 0, 1), WG_PORT);
+const PLAINTEXT_ADDR: SocketAddrV4 = SocketAddrV4::new(*WG_ADDR.ip(), PLAINTEXT_PORT);
+const CRYPTO_ADDR: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new(100, 66, 0, 2), CRYPTO_PORT);
+const CRYPTO_SOCK_ADDR: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), CRYPTO_PORT);
 
 type XRayResult<T> = Result<T, XRayError>;
 
@@ -57,6 +65,8 @@ enum XRayError {
     Time(#[from] SystemTimeError),
     #[error("Failed to send command over channel: {0:?}")]
     ChannelSend(#[from] SendError<TestCmd>),
+    #[error("Pcap error: {0:?}")]
+    Pcap(#[from] PcapError),
 }
 
 impl From<TunnResult<'_>> for XRayError {
@@ -74,20 +84,28 @@ struct CliArgs {
     #[arg(long, default_value_t = 10)]
     packet_count: usize,
     #[arg(long)]
-    csv_name: Option<String>,
+    csv_path: Option<String>,
+    #[arg(long)]
+    pcap_path: Option<String>,
 }
 
 impl CliArgs {
-    fn csv_name(&self) -> String {
-        self.csv_name
-            .as_ref()
-            .map(|s| s.to_lowercase())
-            .unwrap_or_else(|| {
-                format!(
-                    "results/xray_{}_{}_{}.csv",
-                    self.wg, self.test_type, self.packet_count
-                )
-            })
+    fn csv_path(&self) -> String {
+        self.csv_path.as_ref().cloned().unwrap_or_else(|| {
+            format!(
+                "results/xray_{}_{}_{}.csv",
+                self.wg, self.test_type, self.packet_count
+            )
+        })
+    }
+
+    fn pcap_path(&self) -> String {
+        self.pcap_path.as_ref().cloned().unwrap_or_else(|| {
+            format!(
+                "results/xray_{}_{}_{}.pcap",
+                self.wg, self.test_type, self.packet_count
+            )
+        })
     }
 }
 
@@ -96,8 +114,11 @@ async fn main() -> EyreResult<()> {
     color_eyre::install()?;
 
     let cli_args = CliArgs::parse();
+
     let test_type = cli_args.test_type.clone();
     let packet_count = cli_args.packet_count;
+    let csv_path = cli_args.csv_path();
+    let pcap_path = cli_args.pcap_path();
 
     let wg_keys = KeyPair::new();
     let peer_keys = KeyPair::new();
@@ -147,8 +168,36 @@ async fn main() -> EyreResult<()> {
         }
     }
     cmd_tx.send(TestCmd::Done).await?;
+    let mut event_loop = task.await.expect("Awaiting task should be successful")?;
 
-    task.await.expect("Awaiting task should be successful")?;
+    run_command("killall -w tcpdump".to_owned())
+        .map_err(|s| XRayError::ShellCommand(s.to_owned()))?;
+    let pcap_packets = process_pcap(&pcap_path, event_loop.tunn())?;
+
+    let allowed_ports = [WG_PORT, PLAINTEXT_PORT, CRYPTO_PORT];
+    let mut packets = event_loop.packets;
+    for p in pcap_packets {
+        if !allowed_ports.contains(&p.src.port()) || !allowed_ports.contains(&p.dst.port()) {
+            continue;
+        }
+        match (test_type.as_str(), p.src.port(), p.dst.port()) {
+            ("crypto", CRYPTO_PORT, WG_PORT) => {
+                packets[p.send_index as usize].pre_wg_ts = Some(p.ts)
+            }
+            ("crypto", CRYPTO_PORT, PLAINTEXT_PORT) => {
+                packets[p.send_index as usize].post_wg_ts = Some(p.ts)
+            }
+            ("plaintext", PLAINTEXT_PORT, CRYPTO_PORT) => {
+                packets[p.send_index as usize].pre_wg_ts = Some(p.ts)
+            }
+            ("plaintext", WG_PORT, CRYPTO_PORT) => {
+                packets[p.send_index as usize].post_wg_ts = Some(p.ts)
+            }
+            params => println!("Unexpected pcap packet found: {params:?}"),
+        }
+    }
+
+    write_to_csv(&csv_path, &packets)?;
 
     Ok(())
 }

--- a/xray/src/pcap.rs
+++ b/xray/src/pcap.rs
@@ -1,0 +1,104 @@
+use std::net::SocketAddrV4;
+
+use neptun::noise::Tunn;
+use pcap::Capture;
+use pnet::packet::{
+    ethernet::EtherTypes, ip::IpNextHeaderProtocols, ipv4::Ipv4Packet, sll2::SLL2Packet,
+    udp::UdpPacket, Packet,
+};
+
+use crate::{client::Client, utils::Packet as XrayPacket, XRayResult};
+
+#[derive(Debug)]
+pub struct PcapPacket {
+    pub ts: u128,
+    pub src: SocketAddrV4,
+    pub dst: SocketAddrV4,
+    pub was_decrypted: bool,
+    pub send_index: u64,
+}
+
+pub fn process_pcap(pcap_path: &str, mut tunn: Tunn) -> XRayResult<Vec<PcapPacket>> {
+    let mut packets = Vec::new();
+
+    let mut capture = Capture::from_file(pcap_path)?;
+    let mut decrypt_buf = vec![0; 1024];
+
+    while let Ok(packet) = capture.next_packet() {
+        let ts = packet.header.ts;
+        let ts = ts.tv_sec as u128 * 1_000_000 + ts.tv_usec as u128;
+        if let Some(packet) = process_packet(packet.data, ts, &mut tunn, &mut decrypt_buf) {
+            packets.push(packet);
+        }
+    }
+
+    Ok(packets)
+}
+
+fn process_packet(
+    packet_data: &[u8],
+    ts: u128,
+    tunn: &mut Tunn,
+    buf: &mut [u8],
+) -> Option<PcapPacket> {
+    let sll2_packet = match SLL2Packet::new(packet_data) {
+        Some(packet) if matches!(packet.get_protocol_type(), EtherTypes::Ipv4) => packet,
+        _ => return None,
+    };
+
+    let ipv4_packet = match Ipv4Packet::new(sll2_packet.payload()) {
+        Some(packet) if matches!(packet.get_next_level_protocol(), IpNextHeaderProtocols::Udp) => {
+            packet
+        }
+        _ => return None,
+    };
+
+    let udp_packet = match UdpPacket::new(ipv4_packet.payload()) {
+        Some(packet) => packet,
+        _ => return None,
+    };
+
+    let src = SocketAddrV4::new(ipv4_packet.get_source(), udp_packet.get_source());
+    let dst = SocketAddrV4::new(ipv4_packet.get_destination(), udp_packet.get_destination());
+
+    process_udp_packet(&udp_packet, tunn, buf).map(|(was_decrypted, send_index)| PcapPacket {
+        ts,
+        src,
+        dst,
+        was_decrypted,
+        send_index,
+    })
+}
+
+fn process_udp_packet(
+    udp_packet: &UdpPacket,
+    tunn: &mut Tunn,
+    buf: &mut [u8],
+) -> Option<(bool, u64)> {
+    if udp_packet.payload().len() == XrayPacket::send_size() {
+        let send_index = extract_send_index(udp_packet.payload());
+        Some((false, send_index))
+    } else if udp_packet.payload().starts_with(&[4, 0, 0, 0]) {
+        let decrypted_packet = match tunn.decrypt(udp_packet.payload(), buf) {
+            Ok(packet) => packet,
+            Err(_) => return None,
+        };
+        match Client::parse_udp_packet(decrypted_packet) {
+            Ok((_, start, end)) if end - start == XrayPacket::send_size() => {
+                let send_index = extract_send_index(&decrypted_packet[start..]);
+                Some((true, send_index))
+            }
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+fn extract_send_index(bytes: &[u8]) -> u64 {
+    u64::from_le_bytes(
+        bytes[0..8]
+            .try_into()
+            .expect("Slice should have exactly 8 bytes"),
+    )
+}


### PR DESCRIPTION
This PR adds pcap analysis to XRay, though it's likely still not utilized as much as it could, but the infrastructure is now in place.

How it works is that the pcap file is opened in rust when the test is done, since we have the `noise::Tunn` object there that encrypted the packets, and we decrypt the packets after the fact. This requires adding some functions to noise itself, but those are feature gated so they can't be used in the wrong place. The data that is gathered from the pcaps (currently the timestamp provided by tcpdump and the sender index) are written to the CSV file, and then used in the analysis step. The previous histograms have been replaced by stacked historgrams so that the different checkin points can be seen separately.