### PR TITLE
Add notice about testing keys

### DIFF
--- a/xtask/perf/left.sh
+++ b/xtask/perf/left.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+######################################################
+# This script is used to setup testing environment   #
+# for performance measurements. The keys here are    #
+# for testing purposes only and must never be used   #
+# in any real deployments                            #
+######################################################
+
 wireguard-go wg0
 wg set wg0 \
     listen-port 51820 \

--- a/xtask/perf/right.sh
+++ b/xtask/perf/right.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+######################################################
+# This script is used to setup testing environment   #
+# for performance measurements. The keys here are    #
+# for testing purposes only and must never be used   #
+# in any real deployments                            #
+######################################################
+
 wireguard-go wg0
 wg set wg0 \
     listen-port 51820 \


### PR DESCRIPTION
NepTUN does some performance measurements, which requires to setup real connections between peers. For that some test keys has been generated, which are not used in any real deployment. Add a note explicitly stating this fact to avoid confusion.