### PR TITLE
LLT-6071: Reduce log level for DuplicateCounter errors

### DIFF
--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -948,11 +948,19 @@ impl Device {
 
                     match res {
                         TunnResult::Done => {}
-                        TunnResult::Err(e) => {
-                            tracing::error!(message="Decapsulate error",
-                            error=?e,
-                            public_key = peer.public_key.1)
-                        }
+                        TunnResult::Err(e) => match e {
+                            WireGuardError::DuplicateCounter => {
+                                // TODO(LLT-6071): revert back to having error level for all error types
+                                tracing::debug!(message="Decapsulate error",
+                                    error=?e,
+                                    public_key=peer.public_key.1)
+                            }
+                            _ => {
+                                tracing::error!(message="Decapsulate error",
+                                    error=?e,
+                                    public_key = peer.public_key.1)
+                            }
+                        },
                         TunnResult::WriteToNetwork(packet) => {
                             flush = true;
                             if let Err(err) = udp.send(packet) {


### PR DESCRIPTION
This is a cross-porting of a hotfix that was already merged to our boringtun fork.

The underlying issue was that the client got flooded with duplicate counter error logs. This will change the log level until we can fix the underlying issue, to prevent problems for our users in the meantime. 