### PR TITLE
Set custom buffer size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/neptun-cli/src/main.rs
+++ b/neptun-cli/src/main.rs
@@ -76,6 +76,10 @@ fn main() {
                 .long("disable-connected-udp")
                 .action(clap::ArgAction::SetTrue)
                 .help("Disable connected UDP sockets to each peer"),
+            Arg::new("skt-buff-size")
+                .long("socket-buffer-size")
+                .value_parser(value_parser!(i32))
+                .help("Sets socket buffers to custom size"),
             #[cfg(target_os = "linux")]
             Arg::new("disable-multi-queue")
                 .long("disable-multi-queue")
@@ -88,6 +92,7 @@ fn main() {
     let tun_name: String = matches.get_one::<String>("INTERFACE_NAME").unwrap().clone();
     let n_threads: usize = *matches.get_one("threads").unwrap();
     let log_level: Level = *matches.get_one("verbosity").unwrap();
+    let skt_buffer_size = matches.get_one::<i32>("skt-buff-size").copied();
 
     // Create a socketpair to communicate between forked processes
     let (sock1, sock2) = UnixDatagram::pair().unwrap();
@@ -152,6 +157,7 @@ fn main() {
         protect: Arc::new(neptun::device::MakeExternalNeptunNoop),
         firewall_process_inbound_callback: None,
         firewall_process_outbound_callback: None,
+        skt_buffer_size,
     };
 
     let mut device_handle: DeviceHandle = match DeviceHandle::new(&tun_name, config) {

--- a/neptun-cli/src/main.rs
+++ b/neptun-cli/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
     let tun_name: String = matches.get_one::<String>("INTERFACE_NAME").unwrap().clone();
     let n_threads: usize = *matches.get_one("threads").unwrap();
     let log_level: Level = *matches.get_one("verbosity").unwrap();
-    let skt_buffer_size = matches.get_one::<i32>("skt-buff-size").copied();
+    let skt_buffer_size = matches.get_one::<u32>("skt-buff-size").copied();
 
     // Create a socketpair to communicate between forked processes
     let (sock1, sock2) = UnixDatagram::pair().unwrap();

--- a/neptun-cli/src/main.rs
+++ b/neptun-cli/src/main.rs
@@ -78,7 +78,7 @@ fn main() {
                 .help("Disable connected UDP sockets to each peer"),
             Arg::new("skt-buff-size")
                 .long("socket-buffer-size")
-                .value_parser(value_parser!(i32))
+                .value_parser(value_parser!(u32))
                 .help("Sets socket buffers to custom size"),
             #[cfg(target_os = "linux")]
             Arg::new("disable-multi-queue")

--- a/neptun/src/device/integration_tests/mod.rs
+++ b/neptun/src/device/integration_tests/mod.rs
@@ -272,6 +272,7 @@ mod tests {
                     protect: Arc::new(crate::device::MakeExternalNeptunNoop),
                     firewall_process_inbound_callback: None,
                     firewall_process_outbound_callback: None,
+                    skt_buffer_size: None,
                 },
             )
         }
@@ -561,6 +562,7 @@ mod tests {
                 protect: Arc::new(crate::device::MakeExternalNeptunNoop),
                 firewall_process_inbound_callback: None,
                 firewall_process_outbound_callback: None,
+                skt_buffer_size: None,
             },
         );
 
@@ -849,6 +851,7 @@ mod tests {
                 protect: Arc::new(crate::device::MakeExternalNeptunNoop),
                 firewall_process_inbound_callback: None,
                 firewall_process_outbound_callback: None,
+                skt_buffer_size: None,
             },
         );
 

--- a/neptun/src/device/peer.rs
+++ b/neptun/src/device/peer.rs
@@ -112,7 +112,7 @@ impl Peer {
     pub fn connect_endpoint(
         &self,
         port: u16,
-        skt_buffer_size: Option<i32>,
+        skt_buffer_size: Option<u32>,
     ) -> Result<socket2::Socket, Error> {
         let mut endpoint = self.endpoint.write();
 

--- a/neptun/src/device/peer.rs
+++ b/neptun/src/device/peer.rs
@@ -9,7 +9,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, SocketAddrV4, S
 use std::str::FromStr;
 use std::sync::Arc;
 
-use crate::device::{AllowedIps, Error, MakeExternalNeptun};
+use crate::device::{modify_skt_buffer_size, AllowedIps, Error, MakeExternalNeptun};
 use crate::noise::Tunn;
 
 use std::os::fd::AsRawFd;
@@ -109,7 +109,11 @@ impl Peer {
         endpoint.addr = Some(addr);
     }
 
-    pub fn connect_endpoint(&self, port: u16) -> Result<socket2::Socket, Error> {
+    pub fn connect_endpoint(
+        &self,
+        port: u16,
+        skt_buffer_size: Option<i32>,
+    ) -> Result<socket2::Socket, Error> {
         let mut endpoint = self.endpoint.write();
 
         if endpoint.conn.is_some() {
@@ -142,6 +146,10 @@ impl Peer {
         );
 
         endpoint.conn = Some(udp_conn.try_clone().unwrap());
+
+        if let Some(buffer_size) = skt_buffer_size {
+            modify_skt_buffer_size(udp_conn.as_raw_fd(), buffer_size);
+        }
 
         Ok(udp_conn)
     }
@@ -215,6 +223,6 @@ mod tests {
             Arc::new(crate::device::MakeExternalNeptunNoop),
         );
 
-        peer.connect_endpoint(12345).unwrap();
+        peer.connect_endpoint(12345, None).unwrap();
     }
 }


### PR DESCRIPTION
Tests have found that speeds on Android are limited because of the socket buffers, and changing these values have led to nearly double the speeds. Make socket buffer size as configurable from upstream.