### PR TITLE
Refactor setting socket buffer prints friendlier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +889,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/neptun/Cargo.toml
+++ b/neptun/Cargo.toml
@@ -45,6 +45,7 @@ nix = { version = "0.29", default-features = false, features = [
     "ioctl",
     "time",
     "user",
+    "socket",
 ] }
 
 [dev-dependencies]

--- a/neptun/src/device/peer.rs
+++ b/neptun/src/device/peer.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use crate::device::{modify_skt_buffer_size, AllowedIps, Error, MakeExternalNeptun};
 use crate::noise::Tunn;
 
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd};
 
 #[derive(Default, Debug)]
 pub struct Endpoint {
@@ -148,7 +148,7 @@ impl Peer {
         endpoint.conn = Some(udp_conn.try_clone().unwrap());
 
         if let Some(buffer_size) = skt_buffer_size {
-            modify_skt_buffer_size(udp_conn.as_raw_fd(), buffer_size);
+            modify_skt_buffer_size(udp_conn.as_fd(), buffer_size);
         }
 
         Ok(udp_conn)


### PR DESCRIPTION
Remove unsafe in setting socket buffer using nix sockets instead of libc