### PR TITLE
Implement io::Write for TunSocket

### DIFF
--- a/neptun/src/device/epoll.rs
+++ b/neptun/src/device/epoll.rs
@@ -6,7 +6,6 @@ use libc::*;
 use parking_lot::Mutex;
 use std::io;
 use std::ops::Deref;
-use std::os::fd::AsRawFd;
 use std::os::unix::io::RawFd;
 use std::ptr::null_mut;
 use std::time::Duration;

--- a/xray/src/client.rs
+++ b/xray/src/client.rs
@@ -184,7 +184,7 @@ impl Client {
                     self.sock.send_to(p, from).await?;
                     bytes_read = 0;
                 }
-                TunnResult::WriteToTunnelV4(p, _) => {
+                TunnResult::WriteToTunnel(p, _) => {
                     let (_, payload_start, payload_end) = Self::parse_udp_packet(p)?;
                     assert!(buf.len() >= payload_end - payload_start);
                     buf[0..payload_end - payload_start]


### PR DESCRIPTION
Add &dyn io::Write parameter to the firewall_process_outbound_callback and pass TunSocket there so that firewall can respond with reject packets.

Additionally TunSocket is stripped from write4/write6 methods which where only needed on darwin platforms. Since the only allowed write to the tun device is the proper IP packet we can read the IP version from the IP header directly in the write method. This way TunSocket can implement io::Write trait.