### PR TITLE
Have separate download/upload tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,9 @@ jobs:
 
   performance-tests:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        test_type: [ upload, download ]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
@@ -55,7 +58,7 @@ jobs:
         sudo apt update
         sudo apt install -y libpcap-dev
     - run: docker build -t neptun-runner:0.0.1 .
-    - run: cargo xtask perf --base main
+    - run: cargo xtask perf --base main --test-type ${{ matrix.test_type }}
 
   xray-tests:
     runs-on: ubuntu-24.04

--- a/xtask/perf/docker-compose.yml
+++ b/xtask/perf/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - ../../target/release:/neptun/current
       - ../../base/target/release:/neptun/base
       - .:/neptun/config
+    environment:
+      - TEST_TYPE=${TEST_TYPE}
 
   right:
     hostname: right
@@ -36,6 +38,8 @@ services:
       - ../../target/release:/neptun/current
       - ../../base/target/release:/neptun/base
       - .:/neptun/config
+    environment:
+      - TEST_TYPE=${TEST_TYPE}
 
 networks:
   default:

--- a/xtask/perf/left.sh
+++ b/xtask/perf/left.sh
@@ -7,6 +7,14 @@
 # in any real deployments                            #
 ######################################################
 
+if [ "$TEST_TYPE" = "download" ]; then
+    ip link add dev wg1 type wireguard
+    ip link add dev wg2 type wireguard
+else
+    /neptun/base/neptun-cli --disable-drop-privileges wg1
+    /neptun/current/neptun-cli --disable-drop-privileges wg2
+fi
+
 wireguard-go wg0
 wg set wg0 \
     listen-port 51820 \
@@ -17,7 +25,6 @@ wg set wg0 \
 ip address add dev wg0 10.0.0.1/24
 ip link set up dev wg0
 
-/neptun/base/neptun-cli --disable-drop-privileges wg1
 wg set wg1 \
     listen-port 51821 \
     private-key <(echo sKZoT3qgxDm1bWny+1ttoi00qS2KXvo1L4Zb265wr3c=) \
@@ -27,7 +34,6 @@ wg set wg1 \
 ip address add dev wg1 10.0.1.1/24
 ip link set up dev wg1
 
-/neptun/current/neptun-cli --disable-drop-privileges wg2
 wg set wg2 \
     listen-port 51822 \
     private-key <(echo 0Fn5JWI1QGDiaVYLDBSLklIEBUujfpX1oH/UGI2D62k=) \
@@ -50,11 +56,11 @@ echo "TCP bidirectional tests"
 
 echo
 echo "Base NepTUN:"
-iperf3 -i 60 -t 120 --bidir -c 10.0.1.2
+iperf3 -i 60 -t 120 -c 10.0.1.2
 
 echo
 echo "Current NepTUN:"
-iperf3 -i 60 -t 120 --bidir -c 10.0.2.2
+iperf3 -i 60 -t 120 -c 10.0.2.2
 
 sleep 1
 echo

--- a/xtask/perf/right.sh
+++ b/xtask/perf/right.sh
@@ -7,6 +7,14 @@
 # in any real deployments                            #
 ######################################################
 
+if [ "$TEST_TYPE" = "download" ]; then
+    /neptun/base/neptun-cli --disable-drop-privileges wg1
+    /neptun/current/neptun-cli --disable-drop-privileges wg2
+else
+    ip link add dev wg1 type wireguard
+    ip link add dev wg2 type wireguard
+fi
+
 wireguard-go wg0
 wg set wg0 \
     listen-port 51820 \
@@ -17,7 +25,6 @@ wg set wg0 \
 ip address add dev wg0 10.0.0.2/24
 ip link set up dev wg0
 
-/neptun/base/neptun-cli --disable-drop-privileges wg1
 wg set wg1 \
     listen-port 51821 \
     private-key <(echo WAoFbPJ6QaXXltwLqBADFkMG6qLZuivSlkIUv2Sc3lY=) \
@@ -27,7 +34,6 @@ wg set wg1 \
 ip address add dev wg1 10.0.1.2/24
 ip link set up dev wg1
 
-/neptun/current/neptun-cli --disable-drop-privileges wg2
 wg set wg2 \
     listen-port 51822 \
     private-key <(echo eNOePaXKpyN9IjNEDe1a4CzBAwdbLupbF5wfdCUjS18=) \

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -4,8 +4,15 @@ use xshell::{cmd, Shell};
 #[derive(Parser, Debug)]
 pub struct Cmd {
     /// Git ref of the benchmark base
-    #[arg(short, long)]
+    #[arg(short, long, help = "Git reference to use as the benchmark base")]
     base: String,
+    /// Optional test type ("upload", "download")
+    #[arg(
+        short,
+        long,
+        help = "Type of test to run (\"upload\" or \"download\"). Defaults to \"upload\""
+    )]
+    test_type: Option<String>,
 }
 
 struct GitWorktree {
@@ -46,6 +53,10 @@ impl Cmd {
         let worktree = GitWorktree::new("base", &self.base);
         build_neptun_cli(".");
         build_neptun_cli(&worktree.name);
+
+        if let Some(test_type) = &self.test_type {
+            std::env::set_var("TEST_TYPE", test_type);
+        }
 
         let sh = Shell::new().expect("Failed to create shell object");
         cmd!(


### PR DESCRIPTION
Performing neptun <-> neptun tests is not the best way to benchmark performance because it hides where the bottlenecks could be (download or upload).

Instead it is better to isolate the upload and download case in its own tests with the other side as linux native wireguard.