### PR TITLE
Make channel and batched pkts sizes configurable

### DIFF
--- a/neptun-cli/src/main.rs
+++ b/neptun-cli/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
     let tun_name: String = matches.get_one::<String>("INTERFACE_NAME").unwrap().clone();
     let n_threads: usize = *matches.get_one("threads").unwrap();
     let log_level: Level = *matches.get_one("verbosity").unwrap();
-    let skt_buffer_size = matches.get_one::<u32>("skt-buff-size").copied();
+    let skt_buffer_size = matches.get_one::<usize>("skt-buff-size").copied();
 
     // Create a socketpair to communicate between forked processes
     let (sock1, sock2) = UnixDatagram::pair().unwrap();
@@ -158,6 +158,8 @@ fn main() {
         firewall_process_inbound_callback: None,
         firewall_process_outbound_callback: None,
         skt_buffer_size,
+        inter_thread_channel_size: None,
+        max_inter_thread_batched_pkts: None,
     };
 
     let mut device_handle: DeviceHandle = match DeviceHandle::new(&tun_name, config) {

--- a/neptun/src/device/integration_tests/mod.rs
+++ b/neptun/src/device/integration_tests/mod.rs
@@ -273,6 +273,8 @@ mod tests {
                     firewall_process_inbound_callback: None,
                     firewall_process_outbound_callback: None,
                     skt_buffer_size: None,
+                    inter_thread_channel_size: None,
+                    max_inter_thread_batched_pkts: None,
                 },
             )
         }
@@ -563,6 +565,8 @@ mod tests {
                 firewall_process_inbound_callback: None,
                 firewall_process_outbound_callback: None,
                 skt_buffer_size: None,
+                inter_thread_channel_size: None,
+                max_inter_thread_batched_pkts: None,
             },
         );
 
@@ -852,6 +856,8 @@ mod tests {
                 firewall_process_inbound_callback: None,
                 firewall_process_outbound_callback: None,
                 skt_buffer_size: None,
+                inter_thread_channel_size: None,
+                max_inter_thread_batched_pkts: None,
             },
         );
 

--- a/neptun/src/device/peer.rs
+++ b/neptun/src/device/peer.rs
@@ -112,7 +112,7 @@ impl Peer {
     pub fn connect_endpoint(
         &self,
         port: u16,
-        skt_buffer_size: Option<u32>,
+        skt_buffer_size: Option<usize>,
     ) -> Result<socket2::Socket, Error> {
         let mut endpoint = self.endpoint.write();
 


### PR DESCRIPTION
Make the channel and inter thread packets batching feature configurable. If no config is given, then it defaults to the given consts.