### PR TITLE
Backport panic fix to v1

### DIFF
--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -280,7 +280,9 @@ impl DeviceHandle {
     #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     pub fn wait(&mut self) {
         while let Some(thread) = self.threads.pop() {
-            thread.join().unwrap();
+            if let Err(e) = thread.join() {
+                tracing::error!("Unable to gracefully close thread. {:?}", e);
+            }
         }
     }
 

--- a/neptun/src/device/peer.rs
+++ b/neptun/src/device/peer.rs
@@ -94,7 +94,9 @@ impl Peer {
     pub fn shutdown_endpoint(&self) {
         if let Some(conn) = self.endpoint.write().conn.take() {
             tracing::info!("Disconnecting from endpoint");
-            conn.shutdown(Shutdown::Both).unwrap();
+            if let Err(e) = conn.shutdown(Shutdown::Both) {
+                tracing::error!("Error in conn shutdown {}", e);
+            }
         }
     }
 


### PR DESCRIPTION
Target hotfix version is libtelio v5.4.0 which is using neptun v1.0.x. Meaning that the fix must be backported to neptun v1.0.x