### PR TITLE
Revert "bump version to v2.3.1: add 32bit support"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "717e29a243b81f8130e31e24e04fb151b04a44b5a7d05370935f7d937e9de06d"
 
 [[package]]
 name = "neptun"
-version = "2.3.1"
+version = "2.2.1"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/neptun/Cargo.toml
+++ b/neptun/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "neptun"
 description = "an implementation of the WireGuard® protocol designed for portability and speed"
-version = "2.3.1"
+version = "2.2.1"
 authors = [
     "Noah Kennedy <nkennedy@cloudflare.com>",
     "Andy Grover <agrover@cloudflare.com>",


### PR DESCRIPTION
Reverts NordSecurity/NepTUN#52 which should have been v2.2.1 -> v2.2.2 and not v2.2.1 -> v2.3.1