### PR TITLE
Use u64 instead of usize

### DIFF
--- a/neptun/src/noise/handshake.rs
+++ b/neptun/src/noise/handshake.rs
@@ -725,7 +725,7 @@ impl Handshake {
         &mut self,
         dst: &'a mut [u8],
     ) -> Result<&'a mut [u8], WireGuardError> {
-        if dst.len() < super::HANDSHAKE_INIT_SZ {
+        if dst.len() < super::HANDSHAKE_INIT_SZ as usize {
             return Err(WireGuardError::DestinationBufferTooSmall);
         }
 
@@ -798,14 +798,14 @@ impl Handshake {
             }),
         );
 
-        self.append_mac1_and_mac2(local_index, &mut dst[..super::HANDSHAKE_INIT_SZ])
+        self.append_mac1_and_mac2(local_index, &mut dst[..super::HANDSHAKE_INIT_SZ as usize])
     }
 
     fn format_handshake_response<'a>(
         &mut self,
         dst: &'a mut [u8],
     ) -> Result<(&'a mut [u8], Session), WireGuardError> {
-        if dst.len() < super::HANDSHAKE_RESP_SZ {
+        if dst.len() < super::HANDSHAKE_RESP_SZ as usize {
             return Err(WireGuardError::DestinationBufferTooSmall);
         }
 
@@ -890,7 +890,8 @@ impl Handshake {
         let temp2 = b2s_hmac(&temp1, &[0x01]);
         let temp3 = b2s_hmac2(&temp1, &temp2, &[0x02]);
 
-        let dst = self.append_mac1_and_mac2(local_index, &mut dst[..super::HANDSHAKE_RESP_SZ])?;
+        let dst =
+            self.append_mac1_and_mac2(local_index, &mut dst[..super::HANDSHAKE_RESP_SZ as usize])?;
 
         Ok((dst, Session::new(local_index, peer_index, temp2, temp3)))
     }

--- a/neptun/src/noise/integration_tests/mod.rs
+++ b/neptun/src/noise/integration_tests/mod.rs
@@ -46,7 +46,7 @@ mod tests {
             }
         }
 
-        fn assert_tx_rx(&self, tx_bytes: usize, rx_bytes: usize) {
+        fn assert_tx_rx(&self, tx_bytes: u64, rx_bytes: u64) {
             let (_, tx, rx, _, _) = self.tunnel.lock().stats();
             assert_eq!(tx, tx_bytes);
             assert_eq!(rx, rx_bytes);

--- a/neptun/src/noise/rate_limiter.rs
+++ b/neptun/src/noise/rate_limiter.rs
@@ -134,7 +134,7 @@ impl RateLimiter {
         mac1: &[u8],
         dst: &'a mut [u8],
     ) -> Result<&'a mut [u8], WireGuardError> {
-        if dst.len() < super::COOKIE_REPLY_SZ {
+        if dst.len() < super::COOKIE_REPLY_SZ as usize {
             return Err(WireGuardError::DestinationBufferTooSmall);
         }
 
@@ -161,7 +161,7 @@ impl RateLimiter {
 
         encrypted_cookie[16..].copy_from_slice(&tag);
 
-        Ok(&mut dst[..super::COOKIE_REPLY_SZ])
+        Ok(&mut dst[..super::COOKIE_REPLY_SZ as usize])
     }
 
     /// Verify the MAC fields on the datagram, and apply rate limiting if needed

--- a/neptun/src/noise/session.rs
+++ b/neptun/src/noise/session.rs
@@ -199,11 +199,11 @@ impl Session {
         payload_len: usize,
         packet_buffer: &'a mut [u8],
     ) -> Result<&'a mut [u8], WireGuardError> {
-        if packet_buffer.len() < payload_len + super::DATA_OVERHEAD_SZ {
+        if packet_buffer.len() < payload_len + super::DATA_OVERHEAD_SZ as usize {
             tracing::warn!(
                 "Destination packet is too small: {} < {}",
                 packet_buffer.len(),
-                payload_len + super::DATA_OVERHEAD_SZ
+                payload_len + super::DATA_OVERHEAD_SZ as usize
             );
             return Err(WireGuardError::IncorrectPacketLength);
         }


### PR DESCRIPTION
Use u64 instead of usize in rx and tx bytes as the value overflows just after 4GB of data and incorrectly reports state which causing the connection to go from connected -> connecting