### PR TITLE
Improve logging

### DIFF
--- a/neptun/src/noise/timers.rs
+++ b/neptun/src/noise/timers.rs
@@ -10,6 +10,7 @@ use std::time::SystemTime;
 
 #[cfg(feature = "mock-instant")]
 use mock_instant::Instant;
+use x25519_dalek::PublicKey;
 
 #[cfg(not(any(
     feature = "mock-instant",
@@ -41,6 +42,18 @@ pub(crate) const REKEY_ATTEMPT_TIME: Duration = Duration::from_secs(90);
 pub(crate) const REKEY_TIMEOUT: Duration = Duration::from_secs(5);
 const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
 const COOKIE_EXPIRATION_TIME: Duration = Duration::from_secs(120);
+
+// Privacy-aware formatter. Aligns with libtelio approach of logging
+// the first and last few chars of the key for better diagnostics while
+// not revealing the full key.
+fn format_pubkey_short(&key: &PublicKey) -> String {
+    let encoded = base64::encode(key);
+    if encoded.len() <= 8 {
+        encoded
+    } else {
+        format!("{}...{}", &encoded[..4], &encoded[encoded.len() - 4..])
+    }
+}
 
 #[derive(Debug)]
 pub enum TimerName {
@@ -189,8 +202,9 @@ impl Tunn {
         for (i, t) in timers.session_timers.iter_mut().enumerate() {
             if time_now - *t > REJECT_AFTER_TIME {
                 if let Some(session) = self.sessions[i].take() {
-                    tracing::debug!(
+                    tracing::info!(
                         message = "SESSION_EXPIRED(REJECT_AFTER_TIME)",
+                        peer = format_pubkey_short(&self.peer_static_public),
                         session = session.receiving_index
                     );
                 }
@@ -240,7 +254,10 @@ impl Tunn {
             // All ephemeral private keys and symmetric session keys are zeroed out after
             // (REJECT_AFTER_TIME * 3) ms if no new keys have been exchanged.
             if now - session_established >= REJECT_AFTER_TIME * 3 {
-                tracing::error!("CONNECTION_EXPIRED(REJECT_AFTER_TIME * 3)");
+                tracing::info!(
+                    message = "CONNECTION_EXPIRED(REJECT_AFTER_TIME * 3)",
+                    peer = format_pubkey_short(&self.peer_static_public)
+                );
                 self.clear_all();
 
                 if persistent_keepalive > 0 {
@@ -258,7 +275,11 @@ impl Tunn {
                     // the retries give up and cease, and clear all existing packets queued
                     // up to be sent. If a packet is explicitly queued up to be sent, then
                     // this timer is reset.
-                    tracing::error!("CONNECTION_EXPIRED(REKEY_ATTEMPT_TIME)");
+                    tracing::info!(
+                        message = "CONNECTION_EXPIRED
+                        (REKEY_ATTEMPT_TIME)",
+                        peer = format_pubkey_short(&self.peer_static_public)
+                    );
                     self.clear_all();
 
                     if persistent_keepalive > 0 {
@@ -275,7 +296,10 @@ impl Tunn {
                     // A handshake initiation is retried after REKEY_TIMEOUT + jitter ms,
                     // if a response has not been received, where jitter is some random
                     // value between 0 and 333 ms.
-                    tracing::warn!("HANDSHAKE(REKEY_TIMEOUT)");
+                    tracing::debug!(
+                        message = "HANDSHAKE(REKEY_TIMEOUT)",
+                        peer = format_pubkey_short(&self.peer_static_public)
+                    );
                     handshake_initiation_required = true;
                 }
             } else {
@@ -288,7 +312,10 @@ impl Tunn {
                     if session_established < data_packet_sent
                         && now - session_established >= REKEY_AFTER_TIME
                     {
-                        tracing::debug!("HANDSHAKE(REKEY_AFTER_TIME (on send))");
+                        tracing::debug!(
+                            message = "HANDSHAKE(REKEY_AFTER_TIME (on send))",
+                            peer = format_pubkey_short(&self.peer_static_public)
+                        );
                         handshake_initiation_required = true;
                     }
 
@@ -300,10 +327,11 @@ impl Tunn {
                         && now - session_established
                             >= REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - REKEY_TIMEOUT
                     {
-                        tracing::warn!(
-                            "HANDSHAKE(REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - \
+                        tracing::debug!(
+                            message = "HANDSHAKE(REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - \
                         REKEY_TIMEOUT \
-                        (on receive))"
+                        (on receive))",
+                            peer = format_pubkey_short(&self.peer_static_public)
                         );
                         handshake_initiation_required = true;
                     }
@@ -320,7 +348,10 @@ impl Tunn {
                     })
                     .unwrap_or_default()
                 {
-                    tracing::warn!("HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)");
+                    tracing::debug!(
+                        message = "HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)",
+                        peer = format_pubkey_short(&self.peer_static_public)
+                    );
                     handshake_initiation_required = true;
                     self.timers.want_handshake_since = None;
                 }
@@ -332,7 +363,10 @@ impl Tunn {
                         && now - aut_packet_sent >= KEEPALIVE_TIMEOUT
                         && mem::replace(&mut self.timers.want_keepalive, false)
                     {
-                        tracing::debug!("KEEPALIVE(KEEPALIVE_TIMEOUT)");
+                        tracing::debug!(
+                            message = "KEEPALIVE(KEEPALIVE_TIMEOUT)",
+                            peer = format_pubkey_short(&self.peer_static_public)
+                        );
                         keepalive_required = true;
                     }
 
@@ -342,7 +376,10 @@ impl Tunn {
                             >= Duration::from_secs(persistent_keepalive as _))
                             || self.time_since_last_handshake().is_none())
                     {
-                        tracing::debug!("KEEPALIVE(PERSISTENT_KEEPALIVE)");
+                        tracing::debug!(
+                            message = "KEEPALIVE(PERSISTENT_KEEPALIVE)",
+                            peer = format_pubkey_short(&self.peer_static_public)
+                        );
                         self.timer_tick(TimePersistentKeepalive);
                         keepalive_required = true;
                     }


### PR DESCRIPTION
Problem:
- Error severity is used for natural WireGuard state machine transition which is misleading as we do not treat it as an error
- It's hard to identify which state transitions belong to which peer

Solution:
- Convert handshake related log severity to `debug` and session management to `info`
- As in libtelio - log first and last 4 bytes of public key