### PR TITLE
LLT-7073 Add Apple platform specific packet processing

### DIFF
--- a/neptun/src/device/integration_tests/mod.rs
+++ b/neptun/src/device/integration_tests/mod.rs
@@ -295,66 +295,6 @@ mod tests {
             }
         }
 
-        #[cfg(target_os = "macos")]
-        /// Starts the tunnel
-        fn start(&mut self) {
-            // Assign the ipv4 address to the interface
-            Command::new("ifconfig")
-                .args(&[
-                    &self.name,
-                    &self.addr_v4.to_string(),
-                    &self.addr_v4.to_string(),
-                    "alias",
-                ])
-                .status()
-                .expect("failed to assign ip to tunnel");
-
-            // Assign the ipv6 address to the interface
-            Command::new("ifconfig")
-                .args(&[
-                    &self.name,
-                    "inet6",
-                    &self.addr_v6.to_string(),
-                    "prefixlen",
-                    "128",
-                    "alias",
-                ])
-                .status()
-                .expect("failed to assign ipv6 to tunnel");
-
-            // Start the tunnel
-            Command::new("ifconfig")
-                .args(&[&self.name, "up"])
-                .status()
-                .expect("failed to start the tunnel");
-
-            self.started = true;
-
-            // Add each peer to the routing table
-            for p in &self.peers {
-                for r in &p.allowed_ips {
-                    let inet_flag = match r.ip {
-                        IpAddr::V4(_) => "-inet",
-                        IpAddr::V6(_) => "-inet6",
-                    };
-
-                    Command::new("route")
-                        .args(&[
-                            "-q",
-                            "-n",
-                            "add",
-                            inet_flag,
-                            &format!("{}/{}", r.ip, r.cidr),
-                            "-interface",
-                            &self.name,
-                        ])
-                        .status()
-                        .expect("failed to add route");
-                }
-            }
-        }
-
-        #[cfg(target_os = "linux")]
         /// Starts the tunnel
         fn start(&mut self) {
             configure_utun(&self.name, self.addr_v4, self.addr_v6, &self.peers);
@@ -442,7 +382,7 @@ mod tests {
 
     #[test]
     #[ignore]
-    /// Test that send_uapi_cmd interface works corretly
+    /// Test that send_uapi_cmd interface works correctly
     fn test_wireguard_get_on_device() {
         let wg = WGHandle::init("192.0.2.0".parse().unwrap(), "::2".parse().unwrap());
         let response = wg.wg_uapi_device_cmd("get=1\n\n");
@@ -451,6 +391,7 @@ mod tests {
 
     #[test]
     #[ignore]
+    #[cfg(not(target_os = "macos"))] // macOS implementation does not support UAPI command chaining within a single connection
     fn test_wireguard_uapi_chaining() {
         let wg = WGHandle::init("192.0.2.0".parse().unwrap(), "::2".parse().unwrap());
 
@@ -677,8 +618,15 @@ mod tests {
         wg.name = new_name;
         wg.device.set_iface(new_iface).unwrap();
 
+        #[cfg(target_os = "linux")]
         Command::new("ip")
             .args(["link", "delete", &old_name])
+            .status()
+            .expect("failed to delete old interface");
+
+        #[cfg(target_os = "macos")]
+        Command::new("ifconfig")
+            .args([&old_name, "down"])
             .status()
             .expect("failed to delete old interface");
 
@@ -702,8 +650,15 @@ mod tests {
         wg.name = new_name;
         wg.device.set_iface(new_iface).unwrap();
 
+        #[cfg(target_os = "linux")]
         Command::new("ip")
             .args(["link", "delete", &old_name])
+            .status()
+            .expect("failed to delete old interface");
+
+        #[cfg(target_os = "macos")]
+        Command::new("ifconfig")
+            .args([&old_name, "down"])
             .status()
             .expect("failed to delete old interface");
 
@@ -988,6 +943,7 @@ mod tests {
             t.join().unwrap();
         }
     }
+
     #[cfg(target_os = "linux")]
     fn remove_routing(name: &str, peers: &[Arc<Peer>]) {
         for p in peers {
@@ -1002,6 +958,30 @@ mod tests {
                     ])
                     .status()
                     .expect("failed to add route");
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn remove_routing(name: &str, peers: &[Arc<Peer>]) {
+        for p in peers {
+            for r in &p.allowed_ips {
+                let inet_flag = match r.ip {
+                    IpAddr::V4(_) => "-inet",
+                    IpAddr::V6(_) => "-inet6",
+                };
+                Command::new("route")
+                    .args([
+                        "-q",
+                        "-n",
+                        "delete",
+                        inet_flag,
+                        &format!("{}/{}", r.ip, r.cidr),
+                        "-interface",
+                        name,
+                    ])
+                    .status()
+                    .expect("failed to delete route");
             }
         }
     }
@@ -1033,6 +1013,56 @@ mod tests {
                         &format!("{}/{}", r.ip, r.cidr),
                         "dev",
                         &name,
+                    ])
+                    .status()
+                    .expect("failed to add route");
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn configure_utun(name: &str, addr_v4: IpAddr, addr_v6: IpAddr, peers: &[Arc<Peer>]) {
+        Command::new("ifconfig")
+            .args([name, &addr_v4.to_string(), &addr_v4.to_string(), "alias"])
+            .status()
+            .expect("failed to assign ip to tunnel");
+
+        // Assign the ipv6 address to the interface
+        Command::new("ifconfig")
+            .args([
+                name,
+                "inet6",
+                &addr_v6.to_string(),
+                "prefixlen",
+                "128",
+                "alias",
+            ])
+            .status()
+            .expect("failed to assign ipv6 to tunnel");
+
+        // Set MTU and bring up the interface
+        Command::new("ifconfig")
+            .args([name, "mtu", "1400", "up"])
+            .status()
+            .expect("failed to start the tunnel");
+
+        // Add routes for each peer's allowed IPs
+        for p in peers {
+            for r in &p.allowed_ips {
+                let inet_flag = match r.ip {
+                    IpAddr::V4(_) => "-inet",
+                    IpAddr::V6(_) => "-inet6",
+                };
+
+                Command::new("route")
+                    .args([
+                        "-q",
+                        "-n",
+                        "add",
+                        inet_flag,
+                        &format!("{}/{}", r.ip, r.cidr),
+                        "-interface",
+                        name,
                     ])
                     .status()
                     .expect("failed to add route");

--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -222,6 +222,39 @@ struct TunnelWorkerData {
     buf_len: usize,
 }
 
+enum IfaceReadResult<'a> {
+    Packet { payload: &'a [u8], peer: Arc<Peer> },
+    Exhausted,
+    Fatal,
+    Skip,
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+enum BatchResult {
+    Continue,
+    Exhausted,
+    Fatal,
+}
+
+struct UnexpectedEncapsulationResult;
+
+struct CheckedMtu(usize);
+
+impl CheckedMtu {
+    fn new(mtu: usize) -> Option<Self> {
+        if mtu + WG_HEADER_OFFSET > MAX_PKT_SIZE {
+            tracing::error!("Insufficient packet buffer size");
+            None
+        } else {
+            Some(Self(mtu))
+        }
+    }
+
+    fn get(&self) -> usize {
+        self.0
+    }
+}
+
 #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 type EventLoopThreads = Result<(Vec<JoinHandle<()>>, Arc<Lock<Vec<Arc<TunSocket>>>>), Error>;
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
@@ -1246,133 +1279,6 @@ impl Device {
         Ok(())
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
-    fn register_read_iface_handler(&self, iface: Arc<TunSocket>) -> Result<(), Error> {
-        self.queue.new_event(
-            iface.as_raw_fd(),
-            Box::new(move |d, t| {
-                let mtu = d.mtu.load(Ordering::Relaxed);
-
-                let (udp4, udp6) = match (d.udp4.as_ref(), d.udp6.as_ref()) {
-                    (Some(u4), Some(u6)) => (u4, u6),
-                    _ => {
-                        tracing::error!("Not connected");
-                        return Action::Exit;
-                    }
-                };
-
-                if mtu + WG_HEADER_OFFSET > MAX_PKT_SIZE {
-                    tracing::error!("Insufficient packet buffer size");
-                    return Action::Exit;
-                }
-
-                let peers = &d.peers_by_ip;
-
-                for _ in 0..MAX_ITR {
-                    #[allow(clippy::indexing_slicing)] // Size already checked above
-                    let src = match iface.read(&mut t.dst_buf[WG_HEADER_OFFSET..mtu + WG_HEADER_OFFSET]) {
-                        Ok(src) => src,
-                        Err(Error::IfaceRead(e)) => {
-                            let ek = e.kind();
-                            if ek == io::ErrorKind::Interrupted || ek == io::ErrorKind::WouldBlock {
-                                break;
-                            }
-                            tracing::error!(
-                                message = "Fatal read error on tun interface: errno", error = ?e
-                            );
-                            return Action::Exit;
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                message = "Unexpected error on tun interface", error = ?e
-                            );
-                            return Action::Exit;
-                        }
-                    };
-
-                    let dst_addr = match Tunn::dst_address(src) {
-                        Some(addr) => addr,
-                        None => continue,
-                    };
-
-                    let peer = match peers.find(dst_addr) {
-                        Some(peer) => peer,
-                        None => continue,
-                    };
-
-                    if let Some(callback) = &d.config.firewall_process_outbound_callback {
-                        if !callback(&peer.public_key.0, src, &mut t.iface.as_ref()) {
-                            continue;
-                        }
-                    }
-
-                    let len = src.len();
-
-                    let res = {
-                        let mut tun = peer.tunnel.lock();
-                        tun.encapsulate_in_place(len, &mut t.dst_buf[..])
-                    };
-
-                    match res {
-                        TunnResult::Done => {}
-                        TunnResult::Err(e) => {
-                            tracing::error!(message = "Encapsulate error",
-                                error = ?e,
-                                public_key = peer.public_key.1)
-                        }
-                        TunnResult::WriteToNetwork(packet) => {
-                            let endpoint = peer.endpoint();
-                            if let Some(conn) = endpoint.conn.as_ref() {
-                                if let Err(err) = conn.send(packet) {
-                                    tracing::debug!(message = "Failed to send packet with the connected socket", error = ?err);
-                                    drop(endpoint);
-                                    peer.shutdown_endpoint();
-                                } else {
-                                    tracing::trace!(
-                                        "Pkt -> ConnSock ({:?}), len: {}",
-                                        endpoint.addr,
-                                        packet.len(),
-                                    );
-                                }
-                            } else if let Some(addr @ SocketAddr::V4(_)) = endpoint.addr {
-                                if let Err(err) = udp4.send_to(packet, &addr.into()) {
-                                    tracing::warn!(message = "Failed to write packet to network v4", error = ?err, dst = ?addr);
-                                } else {
-                                    tracing::trace!(
-                                        message = "Writing packet to network v4",
-                                        packet_length = packet.len(),
-                                        src_addr = ?addr,
-                                        public_key = peer.public_key.1
-                                    );
-                                }
-                            } else if let Some(addr @ SocketAddr::V6(_)) = endpoint.addr {
-                                if let Err(err) = udp6.send_to(packet, &addr.into()) {
-                                    tracing::warn!(message = "Failed to write packet to network v6", error = ?err, dst = ?addr);
-                                } else {
-                                    tracing::trace!(
-                                        message = "Writing packet to network v6",
-                                        packet_length = packet.len(),
-                                        src_addr = ?addr,
-                                        public_key = peer.public_key.1
-                                    );
-                                }
-                            } else {
-                                tracing::error!("No endpoint");
-                            }
-                        }
-                        _ => {
-                            tracing::error!("Unexpected result from encapsulate");
-                            return Action::Exit;
-                        }
-                    }
-                }
-                Action::Continue
-            }),
-        )?;
-        Ok(())
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     fn register_read_iface_handler(&self, iface: Arc<TunSocket>) -> Result<(), Error> {
         self.queue.new_event(
             iface.as_raw_fd(),
@@ -1383,76 +1289,57 @@ impl Device {
                 // * Determine peer based on packet destination ip
                 // * Encapsulate the packet for the given peer
                 // * Send encapsulated packet to the peer's endpoint
-                let mtu = d.mtu.load(Ordering::Relaxed);
 
-                if mtu + WG_HEADER_OFFSET > MAX_PKT_SIZE {
-                    tracing::error!("Insufficient packet buffer size");
-                    return Action::Exit;
-                }
+                let mtu = match CheckedMtu::new(d.mtu.load(Ordering::Relaxed)) {
+                    Some(m) => m,
+                    None => return Action::Exit,
+                };
 
                 let peers = &d.peers_by_ip;
-                let max_batched_pkts = d
-                    .config
-                    .max_inter_thread_batched_pkts
-                    .unwrap_or(MAX_INTERTHREAD_BATCHED_PKTS);
-                loop {
-                    let mut batched_pkts = Vec::with_capacity(max_batched_pkts);
-                    let mut tunnel_buffer_exhausted = false;
-                    for _ in 0..batched_pkts.capacity() {
-                        let mut buffer = [0u8; MAX_PKT_SIZE];
-                        #[allow(clippy::indexing_slicing)] // Size already checked above
-                        let len = match iface
-                            .read(&mut buffer[WG_HEADER_OFFSET..mtu + WG_HEADER_OFFSET])
-                        {
-                            Ok(src) => src.len(),
-                            Err(Error::IfaceRead(e)) => {
-                                let ek = e.kind();
-                                if ek == io::ErrorKind::Interrupted
-                                    || ek == io::ErrorKind::WouldBlock
-                                {
-                                    tunnel_buffer_exhausted = true;
+
+                // On Apple platforms, process the packets inline
+                #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+                {
+                    let t = _t;
+                    let (udp4, udp6) = match (d.udp4.as_ref(), d.udp6.as_ref()) {
+                        (Some(udp4), Some(udp6)) => (udp4, udp6),
+                        _ => {
+                            tracing::error!("Not connected");
+                            return Action::Exit;
+                        }
+                    };
+                    handle_packet_in_place(d, t, &iface, &mtu, peers, udp4, udp6)
+                }
+
+                // On non-Apple platforms, batch packets and send them to a worker thread for processing
+                #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+                {
+                    let max_batched_pkts = d
+                        .config
+                        .max_inter_thread_batched_pkts
+                        .unwrap_or(MAX_INTERTHREAD_BATCHED_PKTS);
+
+                    loop {
+                        let (batched_pkts, result) =
+                            handle_packet_queued(&iface, &mtu, peers, max_batched_pkts);
+
+                        match result {
+                            BatchResult::Fatal => return Action::Exit,
+                            BatchResult::Continue | BatchResult::Exhausted => {
+                                if let Err(e) = d.tunnel_to_socket_tx.send(batched_pkts) {
+                                    tracing::warn!(
+                                        "Unable to forward data onto network worker {e}"
+                                    );
+                                }
+                                if matches!(result, BatchResult::Exhausted) {
                                     break;
                                 }
-                                tracing::error!(
-                                    message="Fatal read error on tun interface: errno", error=?e
-                                );
-                                return Action::Exit;
                             }
-                            Err(e) => {
-                                tracing::error!(
-                                    message="Unexpected error on tun interface", error=?e
-                                );
-                                return Action::Exit;
-                            }
-                        };
+                        }
+                    }
 
-                        #[allow(clippy::indexing_slicing)] // Size already checked above
-                        let dst_addr = match Tunn::dst_address(
-                            &buffer[WG_HEADER_OFFSET..len + WG_HEADER_OFFSET],
-                        ) {
-                            Some(addr) => addr,
-                            None => continue,
-                        };
-
-                        let peer = match peers.find(dst_addr) {
-                            Some(peer) => peer,
-                            None => continue,
-                        };
-                        batched_pkts.push(NetworkTaskData {
-                            data: buffer,
-                            buf_len: len,
-                            peer: peer.clone(),
-                            iface: iface.clone(),
-                        });
-                    }
-                    if let Err(e) = d.tunnel_to_socket_tx.send(batched_pkts) {
-                        tracing::warn!("Unable to forward data onto network worker {e}");
-                    }
-                    if tunnel_buffer_exhausted {
-                        break;
-                    }
+                    Action::Continue
                 }
-                Action::Continue
             }),
         )?;
         Ok(())
@@ -1460,6 +1347,160 @@ impl Device {
 
     pub fn iface(&self) -> &TunSocket {
         &self.iface
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+fn handle_packet_in_place(
+    device: &LockReadGuard<Device>,
+    thread_data: &mut ThreadData,
+    iface: &Arc<TunSocket>,
+    mtu: &CheckedMtu,
+    peers: &AllowedIps<Arc<Peer>>,
+    udp4: &socket2::Socket,
+    udp6: &socket2::Socket,
+) -> Action {
+    for _ in 0..MAX_ITR {
+        match read_packet(iface, &mut thread_data.dst_buf, mtu, peers) {
+            IfaceReadResult::Exhausted => break,
+            IfaceReadResult::Fatal => return Action::Exit,
+            IfaceReadResult::Skip => continue,
+            IfaceReadResult::Packet { payload, peer } => {
+                if let Some(callback) = &device.config.firewall_process_outbound_callback {
+                    if !callback(&peer.public_key.0, payload, &mut thread_data.iface.as_ref()) {
+                        continue;
+                    }
+                }
+
+                let len = payload.len();
+                if encapsulate_and_send(&peer, &mut thread_data.dst_buf[..], len, udp4, udp6)
+                    .is_err()
+                {
+                    return Action::Exit;
+                }
+            }
+        }
+    }
+    Action::Continue
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+fn handle_packet_queued(
+    iface: &Arc<TunSocket>,
+    mtu: &CheckedMtu,
+    peers: &AllowedIps<Arc<Peer>>,
+    max_batched_pkts: usize,
+) -> (Vec<NetworkTaskData>, BatchResult) {
+    let mut batched_pkts = Vec::with_capacity(max_batched_pkts);
+
+    for _ in 0..batched_pkts.capacity() {
+        let mut buffer = [0u8; MAX_PKT_SIZE];
+        match read_packet(iface, &mut buffer, mtu, peers) {
+            IfaceReadResult::Exhausted => return (batched_pkts, BatchResult::Exhausted),
+            IfaceReadResult::Fatal => return (batched_pkts, BatchResult::Fatal),
+            IfaceReadResult::Skip => continue,
+            IfaceReadResult::Packet { payload, peer } => {
+                let len = payload.len();
+                batched_pkts.push(NetworkTaskData {
+                    data: buffer,
+                    buf_len: len,
+                    peer,
+                    iface: iface.clone(),
+                });
+            }
+        }
+    }
+
+    (batched_pkts, BatchResult::Continue)
+}
+
+fn read_packet<'a>(
+    iface: &Arc<TunSocket>,
+    buf: &'a mut [u8],
+    mtu: &CheckedMtu,
+    peers: &AllowedIps<Arc<Peer>>,
+) -> IfaceReadResult<'a> {
+    #[allow(clippy::indexing_slicing)] // Correct size guaranteed by the CheckedMtu type
+    match iface.read(&mut buf[WG_HEADER_OFFSET..WG_HEADER_OFFSET + mtu.get()]) {
+        Ok(payload) => match Tunn::dst_address(payload) {
+            None => IfaceReadResult::Skip,
+            Some(dst_addr) => match peers.find(dst_addr) {
+                None => IfaceReadResult::Skip,
+                Some(peer) => IfaceReadResult::Packet {
+                    payload,
+                    peer: peer.clone(),
+                },
+            },
+        },
+        Err(Error::IfaceRead(e)) => match e.kind() {
+            io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock => IfaceReadResult::Exhausted,
+            _ => {
+                tracing::error!(message = "Fatal read error on tun interface: errno", error = ?e);
+                IfaceReadResult::Fatal
+            }
+        },
+        Err(e) => {
+            tracing::error!(message = "Unexpected error on tun interface", error = ?e);
+            IfaceReadResult::Fatal
+        }
+    }
+}
+
+fn encapsulate_and_send(
+    peer: &Arc<Peer>,
+    buf: &mut [u8],
+    payload_len: usize,
+    udp4: &socket2::Socket,
+    udp6: &socket2::Socket,
+) -> Result<(), UnexpectedEncapsulationResult> {
+    let res = {
+        let mut tun = peer.tunnel.lock();
+        tun.encapsulate_in_place(payload_len, buf)
+    };
+
+    match res {
+        TunnResult::Done => Ok(()),
+        TunnResult::Err(e) => {
+            tracing::error!(message = "Encapsulate error",
+                error = ?e,
+                public_key = peer.public_key.1);
+            Ok(())
+        }
+        TunnResult::WriteToNetwork(packet) => {
+            let endpoint = peer.endpoint();
+            if let Some(conn) = endpoint.conn.as_ref() {
+                if let Err(err) = conn.send(packet) {
+                    tracing::debug!(message = "Failed to send packet with the connected socket", error = ?err);
+                    drop(endpoint);
+                    peer.shutdown_endpoint();
+                } else {
+                    tracing::trace!(
+                        "Pkt -> ConnSock ({:?}), len: {}",
+                        endpoint.addr,
+                        packet.len()
+                    );
+                }
+            } else if let Some(addr @ SocketAddr::V4(_)) = endpoint.addr {
+                if let Err(err) = udp4.send_to(packet, &addr.into()) {
+                    tracing::warn!(message = "Failed to write packet to network v4", error = ?err, dst = ?addr);
+                } else {
+                    tracing::trace!(message = "Writing packet to network v4", packet_length = packet.len(), src_addr = ?addr, public_key = peer.public_key.1);
+                }
+            } else if let Some(addr @ SocketAddr::V6(_)) = endpoint.addr {
+                if let Err(err) = udp6.send_to(packet, &addr.into()) {
+                    tracing::warn!(message = "Failed to write packet to network v6", error = ?err, dst = ?addr);
+                } else {
+                    tracing::trace!(message = "Writing packet to network v6", packet_length = packet.len(), src_addr = ?addr, public_key = peer.public_key.1);
+                }
+            } else {
+                tracing::error!("No endpoint");
+            }
+            Ok(())
+        }
+        _ => {
+            tracing::error!("Unexpected result from encapsulate");
+            Err(UnexpectedEncapsulationResult)
+        }
     }
 }
 
@@ -1490,63 +1531,9 @@ fn write_to_socket_worker(
                             }
                         }
 
-                        let res = {
-                            let mut tun = element.peer.tunnel.lock();
-                            tun.encapsulate_in_place(len, &mut element.data[..])
-                        };
-                        match res {
-                            TunnResult::Done => {}
-                            TunnResult::Err(e) => {
-                                tracing::error!(message = "Encapsulate error",
-                                    error = ?e,
-                                    public_key = element.peer.public_key.1)
-                            }
-                            TunnResult::WriteToNetwork(packet) => {
-                                let endpoint = element.peer.endpoint();
-                                if let Some(conn) = endpoint.conn.as_ref() {
-                                    // Prefer to send using the connected socket
-                                    if let Err(err) = conn.send(packet) {
-                                        tracing::debug!(message = "Failed to send packet with the connected socket", error = ?err);
-                                        drop(endpoint);
-                                        element.peer.shutdown_endpoint();
-                                    } else {
-                                        tracing::trace!(
-                                            "Pkt -> ConnSock ({:?}), len: {}",
-                                            endpoint.addr,
-                                            packet.len(),
-                                        );
-                                    }
-                                } else if let Some(addr @ SocketAddr::V4(_)) = endpoint.addr {
-                                    if let Err(err) = udp4.send_to(packet, &addr.into()) {
-                                        tracing::warn!(message = "Failed to write packet to network v4", error = ?err, dst = ?addr);
-                                    } else {
-                                        tracing::trace!(
-                                            message = "Writing packet to network v4",
-                                            packet_length = packet.len(),
-                                            src_addr = ?addr,
-                                            public_key = element.peer.public_key.1
-                                        );
-                                    }
-                                } else if let Some(addr @ SocketAddr::V6(_)) = endpoint.addr {
-                                    if let Err(err) = udp6.send_to(packet, &addr.into()) {
-                                        tracing::warn!(message = "Failed to write packet to network v6", error = ?err, dst = ?addr);
-                                    } else {
-                                        tracing::trace!(
-                                            message = "Writing packet to network v6",
-                                            packet_length = packet.len(),
-                                            src_addr = ?addr,
-                                            public_key = element.peer.public_key.1
-                                        );
-                                    }
-                                } else {
-                                    tracing::error!("No endpoint");
-                                }
-                            }
-                            _ => {
-                                tracing::error!("Unexpected result from encapsulate");
-                                continue;
-                            },
-                        };
+                        if encapsulate_and_send(&element.peer, &mut element.data[..], len, &udp4, &udp6).is_err() {
+                            tracing::error!("Unexpected result from encapsulate");
+                        }
                     }
                 }
             }
@@ -1648,12 +1635,12 @@ impl Default for IndexLfsr {
     }
 }
 
-#[cfg(target_os = "linux")]
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn test_setting_skt_buffers() {
         let socket = socket2::Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).unwrap();
         let _res = socket.set_reuse_address(true);
@@ -1667,5 +1654,24 @@ mod tests {
         // According to `man 7 socket` linux doubles the buffer size
         // internally as it assumes half is for internal kernel structures
         assert!(get_buf == (BUFFER_SIZE * 2) as usize);
+    }
+
+    #[test]
+    fn checked_mtu_accepts_mtu_within_bounds() {
+        let mtu = MAX_PKT_SIZE - WG_HEADER_OFFSET;
+        assert!(CheckedMtu::new(mtu).is_some());
+    }
+
+    #[test]
+    fn checked_mtu_boundary_over_limit_is_rejected() {
+        let mtu = MAX_PKT_SIZE - WG_HEADER_OFFSET + 1;
+        assert!(CheckedMtu::new(mtu).is_none());
+    }
+
+    #[test]
+    fn checked_mtu_get_returns_original_value() {
+        let mtu = 1420;
+        let checked = CheckedMtu::new(mtu).unwrap();
+        assert_eq!(checked.get(), mtu);
     }
 }

--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -760,7 +760,27 @@ impl Device {
         self.close_network_worker_tx = Some(close_network_worker_tx);
         self.close_tun_worker_tx = Some(close_tun_worker_tx);
 
-        // Process packet in a seperate thread
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        {
+            let rx_clone = self.tunnel_to_socket_rx.clone();
+            let close_chan_clone = close_network_worker_rx.clone();
+            let udp4_c = udp4.clone();
+            let udp6_c = udp6.clone();
+            let fw_callback = self
+                .config
+                .firewall_process_outbound_callback
+                .as_ref()
+                .map(|f| f.clone());
+            let queue = dispatch::Queue::global(dispatch::QueuePriority::High);
+            let group = dispatch::Group::create();
+            queue.exec_async(move || {
+                group.enter();
+                write_to_socket_worker(rx_clone, close_chan_clone, udp4_c, udp6_c, fw_callback)
+            });
+        }
+
+        // Process packet in a seperate thread for non-Apple platforms
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         for _ in 0..num_cpus::get_physical() {
             let rx_clone = self.tunnel_to_socket_rx.clone();
             let close_chan_clone = close_network_worker_rx.clone();

--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -26,18 +26,16 @@ pub mod tun;
 #[path = "tun_linux.rs"]
 pub mod tun;
 
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+mod packet_workers;
+
 use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::parse_handshake_anon;
 use crate::noise::rate_limiter::RateLimiter;
 use crate::noise::{Packet, Tunn, TunnResult};
 use crate::x25519;
 use allowed_ips::AllowedIps;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-use crossbeam_channel::{Receiver, Sender};
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-use nix::sys::socket as NixSocket;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-use num_cpus;
+use dev_lock::{Lock, LockReadGuard};
 use peer::{AllowedIP, Peer};
 use poll::{EventPoll, EventRef, WaitResult};
 use rand_core::{OsRng, RngCore};
@@ -45,22 +43,23 @@ use socket2::{Domain, Protocol, Type};
 use std::collections::HashMap;
 use std::io::{self, BufReader, BufWriter, Write};
 use std::mem::{swap, MaybeUninit};
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-use std::net::IpAddr;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::os::fd::RawFd;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-use std::os::fd::{AsFd, BorrowedFd};
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-use std::thread::{self, JoinHandle};
+use thiserror::Error;
 use tun::TunSocket;
 
-use dev_lock::{Lock, LockReadGuard};
-use thiserror::Error;
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+use {
+    nix::sys::socket as NixSocket,
+    packet_workers::{PacketWorkers, TunnelWorkerData},
+    std::net::IpAddr,
+    std::os::fd::{AsFd, BorrowedFd},
+    std::thread::{self, JoinHandle},
+};
 
 const HANDSHAKE_RATE_LIMIT: u64 = 100; // The number of handshakes per second we can tolerate before using cookies
 
@@ -69,10 +68,6 @@ const HANDSHAKE_RATE_LIMIT: u64 = 100; // The number of handshakes per second we
 const MAX_PKT_SIZE: usize = 1550;
 const MAX_ITR: usize = 100;
 const WG_HEADER_OFFSET: usize = 16;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-const CHANNEL_SIZE: usize = 500;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-const MAX_INTERTHREAD_BATCHED_PKTS: usize = 50;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -192,21 +187,7 @@ pub struct Device {
     rate_limiter: Option<Arc<RateLimiter>>,
 
     #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-    close_network_worker_tx: Option<Sender<()>>,
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-    close_tun_worker_tx: Option<Sender<()>>,
-
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-    tunnel_to_socket_rx: Receiver<Vec<NetworkTaskData>>,
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-    tunnel_to_socket_tx: Sender<Vec<NetworkTaskData>>,
-
-    // UDP socket -> processing -> socket_to_tunnel_tx ->
-    // [thread boundary] -> socket_to_tunnel_rx -> -> write to tunnel
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-    socket_to_tunnel_rx: Receiver<Vec<TunnelWorkerData>>,
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-    socket_to_tunnel_tx: Sender<Vec<TunnelWorkerData>>,
+    workers: PacketWorkers,
 }
 
 struct ThreadData {
@@ -216,35 +197,11 @@ struct ThreadData {
     update_seq: u32,
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-struct NetworkTaskData {
-    data: [u8; MAX_PKT_SIZE],
-    buf_len: usize,
-    peer: Arc<Peer>,
-    iface: Arc<TunSocket>,
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-struct TunnelWorkerData {
-    buffer: [u8; MAX_PKT_SIZE],
-    peer: Arc<Peer>,
-    iface: Arc<TunSocket>,
-    addr: IpAddr,
-    buf_len: usize,
-}
-
 enum IfaceReadResult<'a> {
     Packet { payload: &'a [u8], peer: Arc<Peer> },
     Exhausted,
     Fatal,
     Skip,
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-enum BatchResult {
-    Continue,
-    Exhausted,
-    Fatal,
 }
 
 struct CheckedMtu(usize);
@@ -683,11 +640,7 @@ impl Device {
         let iface = Arc::new(tun.set_non_blocking()?);
         let mtu = iface.mtu()?;
         #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-        let channel_size = config.inter_thread_channel_size.unwrap_or(CHANNEL_SIZE);
-        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-        let (tunnel_to_socket_tx, tunnel_to_socket_rx) = crossbeam_channel::bounded(channel_size);
-        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-        let (socket_to_tunnel_tx, socket_to_tunnel_rx) = crossbeam_channel::bounded(channel_size);
+        let workers = PacketWorkers::new(&config);
 
         let mut device = Device {
             queue: Arc::new(poll),
@@ -708,19 +661,9 @@ impl Device {
             cleanup_paths: Default::default(),
             mtu: AtomicUsize::new(mtu),
             rate_limiter: None,
-            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-            tunnel_to_socket_tx,
-            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-            tunnel_to_socket_rx,
-            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-            close_network_worker_tx: None,
-            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-            socket_to_tunnel_tx,
-            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-            socket_to_tunnel_rx,
-            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-            close_tun_worker_tx: None,
             update_seq: 0,
+            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+            workers,
         };
 
         if device.config.open_uapi_socket {
@@ -754,20 +697,7 @@ impl Device {
         // First close any existing open socket, and remove them from the event loop
         if let Some(s) = self.udp4.take() {
             #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-            {
-                if let Some(close_network_worker_tx) = &self.close_network_worker_tx {
-                    for _ in 0..num_cpus::get_physical() {
-                        if let Err(e) = close_network_worker_tx.try_send(()) {
-                            tracing::error!("Unable to close network thread {e}");
-                        }
-                    }
-                }
-                if let Some(close_tun_worker_tx) = &self.close_tun_worker_tx {
-                    if let Err(e) = close_tun_worker_tx.try_send(()) {
-                        tracing::error!("Unable to close tun thread {e}");
-                    }
-                }
-            }
+            self.workers.shutdown();
             unsafe {
                 // This is safe because the event loop is not running yet
                 self.queue.clear_event_by_fd(s.as_raw_fd());
@@ -819,43 +749,7 @@ impl Device {
 
         // Process packet in a separate thread for non-Apple platforms
         #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-        {
-            // Construct a different closing channel per thread
-            let (close_network_worker_tx, close_network_worker_rx) =
-                crossbeam_channel::bounded(num_cpus::get_physical() * 5);
-            let (close_tun_worker_tx, close_tun_worker_rx) = crossbeam_channel::bounded(5);
-
-            self.close_network_worker_tx = Some(close_network_worker_tx);
-            self.close_tun_worker_tx = Some(close_tun_worker_tx);
-
-            for _ in 0..num_cpus::get_physical() {
-                let tunnel_to_socket_rx = self.tunnel_to_socket_rx.clone();
-                let close_chan_clone = close_network_worker_rx.clone();
-                let udp4_c = udp4.clone();
-                let udp6_c = udp6.clone();
-                let fw_callback = self
-                    .config
-                    .firewall_process_outbound_callback
-                    .as_ref()
-                    .map(|f| f.clone());
-                thread::spawn(move || {
-                    write_to_socket_worker(
-                        tunnel_to_socket_rx,
-                        close_chan_clone,
-                        udp4_c,
-                        udp6_c,
-                        fw_callback,
-                    )
-                });
-            }
-
-            let socket_to_tunnel_rx = self.socket_to_tunnel_rx.clone();
-            let fw_callback = self.config.firewall_process_inbound_callback.clone();
-
-            thread::spawn(move || {
-                write_to_tun_worker(socket_to_tunnel_rx, close_tun_worker_rx, fw_callback)
-            });
-        }
+        self.workers.start(udp4, udp6, &self.config);
 
         self.listen_port = port;
 
@@ -1082,8 +976,8 @@ impl Device {
                         },
                         None => {
                             match Tunn::parse_incoming_packet(packet) {
-                                Ok(packet) => packet,
-                                Err(_) => continue,
+                            Ok(packet) => packet,
+                            Err(_) => continue,
                             }
                         }
                     };
@@ -1161,13 +1055,13 @@ impl Device {
                         }
                     }
 
-                    // This packet was OK, that means we want to create a connected socket for this peer
                     #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
                     {
+                        // This packet was OK, that means we want to create a connected socket for this peer
                         let ip_addr = sock.ip();
                         peer.set_endpoint(sock);
                         if d.config.use_connected_socket {
-                            // No need for aditional checking, as from this point all packets will arive to connected socket handler
+                            // No need for additional checking, as from this point all packets will arrive to connected socket handler
                             if let Ok(sock) = peer.connect_endpoint(d.listen_port, d.config.skt_buffer_size) {
                                 if let Err(e) = d.register_read_conn_skt_handler(Arc::clone(peer), sock, ip_addr) {
                                     tracing::error!("Failed to register connected socket handler {}", e);
@@ -1201,7 +1095,7 @@ impl Device {
                 // The conn_handler handles packet received from a connected UDP socket, associated
                 // with a known peer, this saves us the hustle of finding the right peer. If another
                 // peer gets the same ip, it will be ignored until the socket does not expire.
-                let max_batched_pkts = d.config.max_inter_thread_batched_pkts.unwrap_or(MAX_INTERTHREAD_BATCHED_PKTS);
+                let max_batched_pkts = d.workers.max_batched_pkts;
                 loop {
                     let mut batched_pkts = Vec::with_capacity(max_batched_pkts);
                     let mut socket_buffer_exhausted = false;
@@ -1236,8 +1130,8 @@ impl Device {
                                     }
                                     _ => {
                                         tracing::error!(message="Decapsulate error",
-                                            error=?e,
-                                            public_key = peer.public_key.1)
+                                        error=?e,
+                                        public_key = peer.public_key.1)
                                     }
                                 },
                                 TunnResult::WriteToNetwork(packet) => {
@@ -1281,9 +1175,9 @@ impl Device {
                             break;
                         }
                     }
-                    if let Err(e) = d.socket_to_tunnel_tx.send(batched_pkts) {
-                        tracing::warn!("Unable to forward data onto tunnel worker {e}");
-                    }
+
+                    d.workers.submit_inbound(batched_pkts);
+
                     if socket_buffer_exhausted {
                         break;
                     }
@@ -1315,45 +1209,13 @@ impl Device {
                 // On Apple platforms, process the packets inline
                 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
                 {
-                    let t = _t;
-                    let (udp4, udp6) = match (d.udp4.as_ref(), d.udp6.as_ref()) {
-                        (Some(udp4), Some(udp6)) => (udp4, udp6),
-                        _ => {
-                            tracing::error!("Not connected");
-                            return Action::Continue;
-                        }
-                    };
-                    handle_packet_in_place(d, t, &iface, &mtu, peers, udp4, udp6)
+                    process_iface_inline(d, _t, &iface, &mtu, peers)
                 }
 
                 // On non-Apple platforms, batch packets and send them to a worker thread for processing
                 #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
                 {
-                    let max_batched_pkts = d
-                        .config
-                        .max_inter_thread_batched_pkts
-                        .unwrap_or(MAX_INTERTHREAD_BATCHED_PKTS);
-
-                    loop {
-                        let (batched_pkts, result) =
-                            handle_packet_queued(&iface, &mtu, peers, max_batched_pkts);
-
-                        match result {
-                            BatchResult::Fatal => return Action::Exit,
-                            BatchResult::Continue | BatchResult::Exhausted => {
-                                if let Err(e) = d.tunnel_to_socket_tx.send(batched_pkts) {
-                                    tracing::warn!(
-                                        "Unable to forward data onto network worker {e}"
-                                    );
-                                }
-                                if matches!(result, BatchResult::Exhausted) {
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                    Action::Continue
+                    d.workers.dispatch_iface_read(&iface, &mtu, peers)
                 }
             }),
         )?;
@@ -1366,15 +1228,21 @@ impl Device {
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
-fn handle_packet_in_place(
-    device: &LockReadGuard<Device>,
+fn process_iface_inline(
+    device: &Device,
     thread_data: &mut ThreadData,
     iface: &Arc<TunSocket>,
     mtu: &CheckedMtu,
     peers: &AllowedIps<Arc<Peer>>,
-    udp4: &socket2::Socket,
-    udp6: &socket2::Socket,
 ) -> Action {
+    let (udp4, udp6) = match (device.udp4.as_ref(), device.udp6.as_ref()) {
+        (Some(udp4), Some(udp6)) => (udp4, udp6),
+        _ => {
+            tracing::error!("Not connected");
+            return Action::Continue;
+        }
+    };
+
     for _ in 0..MAX_ITR {
         match read_packet(iface, &mut thread_data.dst_buf, mtu, peers) {
             IfaceReadResult::Exhausted => break,
@@ -1393,36 +1261,6 @@ fn handle_packet_in_place(
         }
     }
     Action::Continue
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-fn handle_packet_queued(
-    iface: &Arc<TunSocket>,
-    mtu: &CheckedMtu,
-    peers: &AllowedIps<Arc<Peer>>,
-    max_batched_pkts: usize,
-) -> (Vec<NetworkTaskData>, BatchResult) {
-    let mut batched_pkts = Vec::with_capacity(max_batched_pkts);
-
-    for _ in 0..batched_pkts.capacity() {
-        let mut buffer = [0u8; MAX_PKT_SIZE];
-        match read_packet(iface, &mut buffer, mtu, peers) {
-            IfaceReadResult::Exhausted => return (batched_pkts, BatchResult::Exhausted),
-            IfaceReadResult::Fatal => return (batched_pkts, BatchResult::Fatal),
-            IfaceReadResult::Skip => continue,
-            IfaceReadResult::Packet { payload, peer } => {
-                let len = payload.len();
-                batched_pkts.push(NetworkTaskData {
-                    data: buffer,
-                    buf_len: len,
-                    peer,
-                    iface: iface.clone(),
-                });
-            }
-        }
-    }
-
-    (batched_pkts, BatchResult::Continue)
 }
 
 fn read_packet<'a>(
@@ -1508,87 +1346,6 @@ fn encapsulate_and_send(
         }
         _ => {
             tracing::error!("Unexpected result from encapsulate");
-        }
-    }
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-fn write_to_socket_worker(
-    tunnel_to_socket_rx: Receiver<Vec<NetworkTaskData>>,
-    close_chan: Receiver<()>,
-    udp4: Arc<socket2::Socket>,
-    udp6: Arc<socket2::Socket>,
-    firewall_process_outbound_callback: Option<
-        Arc<dyn Fn(&[u8; 32], &[u8], &mut dyn std::io::Write) -> bool + Send + Sync>,
-    >,
-) {
-    loop {
-        crossbeam_channel::select! {
-            recv(tunnel_to_socket_rx) -> element => {
-                if let Ok(mut batched_pkts) = element {
-                    for element in batched_pkts.iter_mut() {
-                        let len = element.buf_len;
-
-                        if let Some(callback) = &firewall_process_outbound_callback {
-                            let buffer = match element.data.get(WG_HEADER_OFFSET..len + WG_HEADER_OFFSET) {
-                                Some(b) => b,
-                                None => continue,
-                            };
-                            if !callback(&element.peer.public_key.0, buffer, &mut element.iface.as_ref()) {
-                                continue;
-                            }
-                        }
-
-                        encapsulate_and_send(&element.peer, &mut element.data[..], len, &udp4, &udp6);
-                    }
-                }
-            }
-            recv(close_chan) -> _n => {
-                break;
-            }
-        }
-    }
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-fn write_to_tun_worker(
-    socket_to_tunnel_rx: Receiver<Vec<TunnelWorkerData>>,
-    close_chan: Receiver<()>,
-    firewall_process_inbound_callback: Option<
-        Arc<dyn Fn(&[u8; 32], &mut [u8]) -> bool + Send + Sync>,
-    >,
-) {
-    loop {
-        crossbeam_channel::select! {
-            recv(socket_to_tunnel_rx) -> batched_pkts => {
-                if let Ok(batched_pkts) = batched_pkts {
-                    for mut t in batched_pkts {
-                        let peer = t.peer;
-
-                        let buffer = match t.buffer.get_mut(..t.buf_len) {
-                            Some(b) => b,
-                            None => {tracing::warn!("Length is greater than buffer space"); continue},
-                        };
-                        if let Some(callback) = &firewall_process_inbound_callback {
-                            if !callback(&peer.public_key.0, buffer) {
-                                continue;
-                            }
-                        }
-                        if peer.is_allowed_ip(t.addr) {
-                            _ = t.iface.as_ref().write(buffer);
-                            tracing::trace!(
-                                message = "Writing packet to tunnel",
-                                packet_length = t.buf_len,
-                                src_addr = ?t.addr,
-                                public_key = peer.public_key.1
-                            );
-                        }
-                    }
-                }
-            }
-            recv(close_chan) -> _n => {
-                break;
-            }
         }
     }
 }

--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -33,7 +33,9 @@ use crate::noise::{Packet, Tunn, TunnResult};
 use crate::x25519;
 use allowed_ips::AllowedIps;
 use crossbeam_channel::{Receiver, Sender};
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 use nix::sys::socket as NixSocket;
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 use num_cpus;
 use peer::{AllowedIP, Peer};
 use poll::{EventPoll, EventRef, WaitResult};
@@ -43,14 +45,15 @@ use std::collections::HashMap;
 use std::io::{self, BufReader, BufWriter, Write};
 use std::mem::{swap, MaybeUninit};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
-use std::os::fd::{AsFd, BorrowedFd, RawFd};
+use std::os::fd::RawFd;
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+use std::os::fd::{AsFd, BorrowedFd};
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::thread;
 #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-use std::thread::JoinHandle;
+use std::thread::{self, JoinHandle};
 use tun::TunSocket;
 
 use dev_lock::{Lock, LockReadGuard};
@@ -181,10 +184,13 @@ pub struct Device {
 
     rate_limiter: Option<Arc<RateLimiter>>,
 
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     close_network_worker_tx: Option<Sender<()>>,
     close_tun_worker_tx: Option<Sender<()>>,
 
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     tunnel_to_socket_rx: Receiver<Vec<NetworkTaskData>>,
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     tunnel_to_socket_tx: Sender<Vec<NetworkTaskData>>,
 
     // UDP socket -> processing -> socket_to_tunnel_tx ->
@@ -200,6 +206,7 @@ struct ThreadData {
     update_seq: u32,
 }
 
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 struct NetworkTaskData {
     data: [u8; MAX_PKT_SIZE],
     buf_len: usize,
@@ -482,6 +489,7 @@ impl Drop for DeviceHandle {
     }
 }
 
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 fn set_sock_opt<T: NixSocket::SetSockOpt<Val = usize>>(
     socket: BorrowedFd<'_>,
     buffer: T,
@@ -494,6 +502,7 @@ fn set_sock_opt<T: NixSocket::SetSockOpt<Val = usize>>(
     }
 }
 
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 fn modify_skt_buffer_size(socket: BorrowedFd<'_>, buffer_size: usize) {
     set_sock_opt(socket, NixSocket::sockopt::RcvBuf, buffer_size, "RcvBuf");
     set_sock_opt(socket, NixSocket::sockopt::SndBuf, buffer_size, "SndBuf");
@@ -632,6 +641,7 @@ impl Device {
         let iface = Arc::new(tun.set_non_blocking()?);
         let mtu = iface.mtu()?;
         let channel_size = config.inter_thread_channel_size.unwrap_or(CHANNEL_SIZE);
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         let (tunnel_to_socket_tx, tunnel_to_socket_rx) = crossbeam_channel::bounded(channel_size);
         let (socket_to_tunnel_tx, socket_to_tunnel_rx) = crossbeam_channel::bounded(channel_size);
 
@@ -654,8 +664,11 @@ impl Device {
             cleanup_paths: Default::default(),
             mtu: AtomicUsize::new(mtu),
             rate_limiter: None,
+            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
             tunnel_to_socket_tx,
+            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
             tunnel_to_socket_rx,
+            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
             close_network_worker_tx: None,
             socket_to_tunnel_tx,
             socket_to_tunnel_rx,
@@ -693,6 +706,7 @@ impl Device {
         // Binds the network facing interfaces
         // First close any existing open socket, and remove them from the event loop
         if let Some(s) = self.udp4.take() {
+            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
             if let Some(close_network_worker_tx) = &self.close_network_worker_tx {
                 for _ in 0..num_cpus::get_physical() {
                     if let Err(e) = close_network_worker_tx.try_send(()) {
@@ -739,6 +753,7 @@ impl Device {
         udp_sock6.set_nonblocking(true)?;
         self.config.protect.make_external(udp_sock6.as_raw_fd());
 
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         if let Some(buffer_size) = self.config.skt_buffer_size {
             // Modify IPv4 IPv6 snd and recv buffers
             modify_skt_buffer_size(udp_sock4.as_fd(), buffer_size);
@@ -754,32 +769,18 @@ impl Device {
         self.udp6 = Some(udp6.clone());
 
         // Construct a different closing channel per thread
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         let (close_network_worker_tx, close_network_worker_rx) =
             crossbeam_channel::bounded(num_cpus::get_physical() * 5);
-        let (close_tun_worker_tx, close_tun_worker_rx) = crossbeam_channel::bounded(5);
-        self.close_network_worker_tx = Some(close_network_worker_tx);
-        self.close_tun_worker_tx = Some(close_tun_worker_tx);
-
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         {
-            let rx_clone = self.tunnel_to_socket_rx.clone();
-            let close_chan_clone = close_network_worker_rx.clone();
-            let udp4_c = udp4.clone();
-            let udp6_c = udp6.clone();
-            let fw_callback = self
-                .config
-                .firewall_process_outbound_callback
-                .as_ref()
-                .map(|f| f.clone());
-            let queue = dispatch::Queue::global(dispatch::QueuePriority::High);
-            let group = dispatch::Group::create();
-            queue.exec_async(move || {
-                group.enter();
-                write_to_socket_worker(rx_clone, close_chan_clone, udp4_c, udp6_c, fw_callback)
-            });
+            self.close_network_worker_tx = Some(close_network_worker_tx);
         }
 
-        // Process packet in a seperate thread for non-Apple platforms
+        let (close_tun_worker_tx, close_tun_worker_rx) = crossbeam_channel::bounded(5);
+        self.close_tun_worker_tx = Some(close_tun_worker_tx);
+
+        // Process packet in a separate thread for non-Apple platforms
         #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         for _ in 0..num_cpus::get_physical() {
             let rx_clone = self.tunnel_to_socket_rx.clone();
@@ -798,6 +799,18 @@ impl Device {
 
         let rx_clone = self.socket_to_tunnel_rx.clone();
         let fw_callback = self.config.firewall_process_inbound_callback.clone();
+
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        {
+            let queue = dispatch::Queue::global(dispatch::QueuePriority::High);
+            let group = dispatch::Group::create();
+            queue.exec_async(move || {
+                group.enter();
+                write_to_tun_worker(rx_clone, close_tun_worker_rx, fw_callback)
+            });
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         thread::spawn(move || write_to_tun_worker(rx_clone, close_tun_worker_rx, fw_callback));
 
         self.listen_port = port;
@@ -1233,6 +1246,133 @@ impl Device {
         Ok(())
     }
 
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+    fn register_read_iface_handler(&self, iface: Arc<TunSocket>) -> Result<(), Error> {
+        self.queue.new_event(
+            iface.as_raw_fd(),
+            Box::new(move |d, t| {
+                let mtu = d.mtu.load(Ordering::Relaxed);
+
+                let (udp4, udp6) = match (d.udp4.as_ref(), d.udp6.as_ref()) {
+                    (Some(u4), Some(u6)) => (u4, u6),
+                    _ => {
+                        tracing::error!("Not connected");
+                        return Action::Exit;
+                    }
+                };
+
+                if mtu + WG_HEADER_OFFSET > MAX_PKT_SIZE {
+                    tracing::error!("Insufficient packet buffer size");
+                    return Action::Exit;
+                }
+
+                let peers = &d.peers_by_ip;
+
+                for _ in 0..MAX_ITR {
+                    #[allow(clippy::indexing_slicing)] // Size already checked above
+                    let src = match iface.read(&mut t.dst_buf[WG_HEADER_OFFSET..mtu + WG_HEADER_OFFSET]) {
+                        Ok(src) => src,
+                        Err(Error::IfaceRead(e)) => {
+                            let ek = e.kind();
+                            if ek == io::ErrorKind::Interrupted || ek == io::ErrorKind::WouldBlock {
+                                break;
+                            }
+                            tracing::error!(
+                                message = "Fatal read error on tun interface: errno", error = ?e
+                            );
+                            return Action::Exit;
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                message = "Unexpected error on tun interface", error = ?e
+                            );
+                            return Action::Exit;
+                        }
+                    };
+
+                    let dst_addr = match Tunn::dst_address(src) {
+                        Some(addr) => addr,
+                        None => continue,
+                    };
+
+                    let peer = match peers.find(dst_addr) {
+                        Some(peer) => peer,
+                        None => continue,
+                    };
+
+                    if let Some(callback) = &d.config.firewall_process_outbound_callback {
+                        if !callback(&peer.public_key.0, src, &mut t.iface.as_ref()) {
+                            continue;
+                        }
+                    }
+
+                    let len = src.len();
+
+                    let res = {
+                        let mut tun = peer.tunnel.lock();
+                        tun.encapsulate_in_place(len, &mut t.dst_buf[..])
+                    };
+
+                    match res {
+                        TunnResult::Done => {}
+                        TunnResult::Err(e) => {
+                            tracing::error!(message = "Encapsulate error",
+                                error = ?e,
+                                public_key = peer.public_key.1)
+                        }
+                        TunnResult::WriteToNetwork(packet) => {
+                            let endpoint = peer.endpoint();
+                            if let Some(conn) = endpoint.conn.as_ref() {
+                                if let Err(err) = conn.send(packet) {
+                                    tracing::debug!(message = "Failed to send packet with the connected socket", error = ?err);
+                                    drop(endpoint);
+                                    peer.shutdown_endpoint();
+                                } else {
+                                    tracing::trace!(
+                                        "Pkt -> ConnSock ({:?}), len: {}",
+                                        endpoint.addr,
+                                        packet.len(),
+                                    );
+                                }
+                            } else if let Some(addr @ SocketAddr::V4(_)) = endpoint.addr {
+                                if let Err(err) = udp4.send_to(packet, &addr.into()) {
+                                    tracing::warn!(message = "Failed to write packet to network v4", error = ?err, dst = ?addr);
+                                } else {
+                                    tracing::trace!(
+                                        message = "Writing packet to network v4",
+                                        packet_length = packet.len(),
+                                        src_addr = ?addr,
+                                        public_key = peer.public_key.1
+                                    );
+                                }
+                            } else if let Some(addr @ SocketAddr::V6(_)) = endpoint.addr {
+                                if let Err(err) = udp6.send_to(packet, &addr.into()) {
+                                    tracing::warn!(message = "Failed to write packet to network v6", error = ?err, dst = ?addr);
+                                } else {
+                                    tracing::trace!(
+                                        message = "Writing packet to network v6",
+                                        packet_length = packet.len(),
+                                        src_addr = ?addr,
+                                        public_key = peer.public_key.1
+                                    );
+                                }
+                            } else {
+                                tracing::error!("No endpoint");
+                            }
+                        }
+                        _ => {
+                            tracing::error!("Unexpected result from encapsulate");
+                            return Action::Exit;
+                        }
+                    }
+                }
+                Action::Continue
+            }),
+        )?;
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     fn register_read_iface_handler(&self, iface: Arc<TunSocket>) -> Result<(), Error> {
         self.queue.new_event(
             iface.as_raw_fd(),
@@ -1323,6 +1463,7 @@ impl Device {
     }
 }
 
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 fn write_to_socket_worker(
     tunnel_to_socket_rx: Receiver<Vec<NetworkTaskData>>,
     close_chan: Receiver<()>,
@@ -1340,13 +1481,13 @@ fn write_to_socket_worker(
                         let len = element.buf_len;
 
                         if let Some(callback) = &firewall_process_outbound_callback {
-                                let buffer = match element.data.get(WG_HEADER_OFFSET..len + WG_HEADER_OFFSET) {
-                                    Some(b) => b,
-                                    None => continue,
-                                };
-                                if !callback(&element.peer.public_key.0, buffer, &mut element.iface.as_ref()) {
-                                    continue;
-                                }
+                            let buffer = match element.data.get(WG_HEADER_OFFSET..len + WG_HEADER_OFFSET) {
+                                Some(b) => b,
+                                None => continue,
+                            };
+                            if !callback(&element.peer.public_key.0, buffer, &mut element.iface.as_ref()) {
+                                continue;
+                            }
                         }
 
                         let res = {

--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -32,6 +32,7 @@ use crate::noise::rate_limiter::RateLimiter;
 use crate::noise::{Packet, Tunn, TunnResult};
 use crate::x25519;
 use allowed_ips::AllowedIps;
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 use crossbeam_channel::{Receiver, Sender};
 #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 use nix::sys::socket as NixSocket;
@@ -44,7 +45,9 @@ use socket2::{Domain, Protocol, Type};
 use std::collections::HashMap;
 use std::io::{self, BufReader, BufWriter, Write};
 use std::mem::{swap, MaybeUninit};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+use std::net::IpAddr;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::os::fd::RawFd;
 #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 use std::os::fd::{AsFd, BorrowedFd};
@@ -65,8 +68,10 @@ const HANDSHAKE_RATE_LIMIT: u64 = 100; // The number of handshakes per second we
 // used in wild networks.
 const MAX_PKT_SIZE: usize = 1550;
 const MAX_ITR: usize = 100;
-const CHANNEL_SIZE: usize = 500;
 const WG_HEADER_OFFSET: usize = 16;
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+const CHANNEL_SIZE: usize = 500;
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 const MAX_INTERTHREAD_BATCHED_PKTS: usize = 50;
 
 #[derive(Debug, thiserror::Error)]
@@ -141,6 +146,8 @@ pub struct DeviceHandle {
 #[derive(Clone)]
 pub struct DeviceConfig {
     pub n_threads: usize,
+    /// On Apple platform, packets are always handled through an unconnected UDP socket.
+    /// Hence, setting this value has no effect when used on Apple platform.
     pub use_connected_socket: bool,
     #[cfg(target_os = "linux")]
     pub use_multi_queue: bool,
@@ -186,6 +193,7 @@ pub struct Device {
 
     #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     close_network_worker_tx: Option<Sender<()>>,
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     close_tun_worker_tx: Option<Sender<()>>,
 
     #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
@@ -195,7 +203,9 @@ pub struct Device {
 
     // UDP socket -> processing -> socket_to_tunnel_tx ->
     // [thread boundary] -> socket_to_tunnel_rx -> -> write to tunnel
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     socket_to_tunnel_rx: Receiver<Vec<TunnelWorkerData>>,
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     socket_to_tunnel_tx: Sender<Vec<TunnelWorkerData>>,
 }
 
@@ -214,6 +224,7 @@ struct NetworkTaskData {
     iface: Arc<TunSocket>,
 }
 
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 struct TunnelWorkerData {
     buffer: [u8; MAX_PKT_SIZE],
     peer: Arc<Peer>,
@@ -235,8 +246,6 @@ enum BatchResult {
     Exhausted,
     Fatal,
 }
-
-struct UnexpectedEncapsulationResult;
 
 struct CheckedMtu(usize);
 
@@ -673,9 +682,11 @@ impl Device {
         // Create a tunnel device
         let iface = Arc::new(tun.set_non_blocking()?);
         let mtu = iface.mtu()?;
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         let channel_size = config.inter_thread_channel_size.unwrap_or(CHANNEL_SIZE);
         #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         let (tunnel_to_socket_tx, tunnel_to_socket_rx) = crossbeam_channel::bounded(channel_size);
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         let (socket_to_tunnel_tx, socket_to_tunnel_rx) = crossbeam_channel::bounded(channel_size);
 
         let mut device = Device {
@@ -703,8 +714,11 @@ impl Device {
             tunnel_to_socket_rx,
             #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
             close_network_worker_tx: None,
+            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
             socket_to_tunnel_tx,
+            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
             socket_to_tunnel_rx,
+            #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
             close_tun_worker_tx: None,
             update_seq: 0,
         };
@@ -740,16 +754,18 @@ impl Device {
         // First close any existing open socket, and remove them from the event loop
         if let Some(s) = self.udp4.take() {
             #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-            if let Some(close_network_worker_tx) = &self.close_network_worker_tx {
-                for _ in 0..num_cpus::get_physical() {
-                    if let Err(e) = close_network_worker_tx.try_send(()) {
-                        tracing::error!("Unable to close network thread {e}");
+            {
+                if let Some(close_network_worker_tx) = &self.close_network_worker_tx {
+                    for _ in 0..num_cpus::get_physical() {
+                        if let Err(e) = close_network_worker_tx.try_send(()) {
+                            tracing::error!("Unable to close network thread {e}");
+                        }
                     }
                 }
-            }
-            if let Some(close_tun_worker_tx) = &self.close_tun_worker_tx {
-                if let Err(e) = close_tun_worker_tx.try_send(()) {
-                    tracing::error!("Unable to close tun thread {e}");
+                if let Some(close_tun_worker_tx) = &self.close_tun_worker_tx {
+                    if let Err(e) = close_tun_worker_tx.try_send(()) {
+                        tracing::error!("Unable to close tun thread {e}");
+                    }
                 }
             }
             unsafe {
@@ -801,50 +817,45 @@ impl Device {
         self.udp4 = Some(udp4.clone());
         self.udp6 = Some(udp6.clone());
 
-        // Construct a different closing channel per thread
-        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-        let (close_network_worker_tx, close_network_worker_rx) =
-            crossbeam_channel::bounded(num_cpus::get_physical() * 5);
-        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-        {
-            self.close_network_worker_tx = Some(close_network_worker_tx);
-        }
-
-        let (close_tun_worker_tx, close_tun_worker_rx) = crossbeam_channel::bounded(5);
-        self.close_tun_worker_tx = Some(close_tun_worker_tx);
-
         // Process packet in a separate thread for non-Apple platforms
         #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-        for _ in 0..num_cpus::get_physical() {
-            let rx_clone = self.tunnel_to_socket_rx.clone();
-            let close_chan_clone = close_network_worker_rx.clone();
-            let udp4_c = udp4.clone();
-            let udp6_c = udp6.clone();
-            let fw_callback = self
-                .config
-                .firewall_process_outbound_callback
-                .as_ref()
-                .map(|f| f.clone());
-            thread::spawn(move || {
-                write_to_socket_worker(rx_clone, close_chan_clone, udp4_c, udp6_c, fw_callback)
-            });
-        }
-
-        let rx_clone = self.socket_to_tunnel_rx.clone();
-        let fw_callback = self.config.firewall_process_inbound_callback.clone();
-
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
         {
-            let queue = dispatch::Queue::global(dispatch::QueuePriority::High);
-            let group = dispatch::Group::create();
-            queue.exec_async(move || {
-                group.enter();
-                write_to_tun_worker(rx_clone, close_tun_worker_rx, fw_callback)
+            // Construct a different closing channel per thread
+            let (close_network_worker_tx, close_network_worker_rx) =
+                crossbeam_channel::bounded(num_cpus::get_physical() * 5);
+            let (close_tun_worker_tx, close_tun_worker_rx) = crossbeam_channel::bounded(5);
+
+            self.close_network_worker_tx = Some(close_network_worker_tx);
+            self.close_tun_worker_tx = Some(close_tun_worker_tx);
+
+            for _ in 0..num_cpus::get_physical() {
+                let tunnel_to_socket_rx = self.tunnel_to_socket_rx.clone();
+                let close_chan_clone = close_network_worker_rx.clone();
+                let udp4_c = udp4.clone();
+                let udp6_c = udp6.clone();
+                let fw_callback = self
+                    .config
+                    .firewall_process_outbound_callback
+                    .as_ref()
+                    .map(|f| f.clone());
+                thread::spawn(move || {
+                    write_to_socket_worker(
+                        tunnel_to_socket_rx,
+                        close_chan_clone,
+                        udp4_c,
+                        udp6_c,
+                        fw_callback,
+                    )
+                });
+            }
+
+            let socket_to_tunnel_rx = self.socket_to_tunnel_rx.clone();
+            let fw_callback = self.config.firewall_process_inbound_callback.clone();
+
+            thread::spawn(move || {
+                write_to_tun_worker(socket_to_tunnel_rx, close_tun_worker_rx, fw_callback)
             });
         }
-
-        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
-        thread::spawn(move || write_to_tun_worker(rx_clone, close_tun_worker_rx, fw_callback));
 
         self.listen_port = port;
 
@@ -1151,14 +1162,17 @@ impl Device {
                     }
 
                     // This packet was OK, that means we want to create a connected socket for this peer
-                    let ip_addr = sock.ip();
-                    peer.set_endpoint(sock);
-                    if d.config.use_connected_socket {
-                        // No need for aditional checking, as from this point all packets will arive to connected socket handler
-                        if let Ok(sock) = peer.connect_endpoint(d.listen_port, d.config.skt_buffer_size) {
-                            if let Err(e) = d.register_read_conn_skt_handler(Arc::clone(peer), sock, ip_addr) {
-                                tracing::error!("Failed to register connected socket handler {}", e);
-                                peer.shutdown_endpoint();
+                    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+                    {
+                        let ip_addr = sock.ip();
+                        peer.set_endpoint(sock);
+                        if d.config.use_connected_socket {
+                            // No need for aditional checking, as from this point all packets will arive to connected socket handler
+                            if let Ok(sock) = peer.connect_endpoint(d.listen_port, d.config.skt_buffer_size) {
+                                if let Err(e) = d.register_read_conn_skt_handler(Arc::clone(peer), sock, ip_addr) {
+                                    tracing::error!("Failed to register connected socket handler {}", e);
+                                    peer.shutdown_endpoint();
+                                }
                             }
                         }
                     }
@@ -1174,6 +1188,7 @@ impl Device {
         Ok(())
     }
 
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     fn register_read_conn_skt_handler(
         &self,
         peer: Arc<Peer>,
@@ -1305,7 +1320,7 @@ impl Device {
                         (Some(udp4), Some(udp6)) => (udp4, udp6),
                         _ => {
                             tracing::error!("Not connected");
-                            return Action::Exit;
+                            return Action::Continue;
                         }
                     };
                     handle_packet_in_place(d, t, &iface, &mtu, peers, udp4, udp6)
@@ -1373,11 +1388,7 @@ fn handle_packet_in_place(
                 }
 
                 let len = payload.len();
-                if encapsulate_and_send(&peer, &mut thread_data.dst_buf[..], len, udp4, udp6)
-                    .is_err()
-                {
-                    return Action::Exit;
-                }
+                encapsulate_and_send(&peer, &mut thread_data.dst_buf[..], len, udp4, udp6);
             }
         }
     }
@@ -1452,19 +1463,18 @@ fn encapsulate_and_send(
     payload_len: usize,
     udp4: &socket2::Socket,
     udp6: &socket2::Socket,
-) -> Result<(), UnexpectedEncapsulationResult> {
+) {
     let res = {
         let mut tun = peer.tunnel.lock();
         tun.encapsulate_in_place(payload_len, buf)
     };
 
     match res {
-        TunnResult::Done => Ok(()),
+        TunnResult::Done => {}
         TunnResult::Err(e) => {
             tracing::error!(message = "Encapsulate error",
                 error = ?e,
                 public_key = peer.public_key.1);
-            Ok(())
         }
         TunnResult::WriteToNetwork(packet) => {
             let endpoint = peer.endpoint();
@@ -1495,11 +1505,9 @@ fn encapsulate_and_send(
             } else {
                 tracing::error!("No endpoint");
             }
-            Ok(())
         }
         _ => {
             tracing::error!("Unexpected result from encapsulate");
-            Err(UnexpectedEncapsulationResult)
         }
     }
 }
@@ -1531,9 +1539,7 @@ fn write_to_socket_worker(
                             }
                         }
 
-                        if encapsulate_and_send(&element.peer, &mut element.data[..], len, &udp4, &udp6).is_err() {
-                            tracing::error!("Unexpected result from encapsulate");
-                        }
+                        encapsulate_and_send(&element.peer, &mut element.data[..], len, &udp4, &udp6);
                     }
                 }
             }
@@ -1544,6 +1550,7 @@ fn write_to_socket_worker(
     }
 }
 
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 fn write_to_tun_worker(
     socket_to_tunnel_rx: Receiver<Vec<TunnelWorkerData>>,
     close_chan: Receiver<()>,

--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -1317,16 +1317,22 @@ fn encapsulate_and_send(
         TunnResult::WriteToNetwork(packet) => {
             let endpoint = peer.endpoint();
             if let Some(conn) = endpoint.conn.as_ref() {
-                if let Err(err) = conn.send(packet) {
-                    tracing::debug!(message = "Failed to send packet with the connected socket", error = ?err);
-                    drop(endpoint);
-                    peer.shutdown_endpoint();
-                } else {
-                    tracing::trace!(
-                        "Pkt -> ConnSock ({:?}), len: {}",
-                        endpoint.addr,
-                        packet.len()
-                    );
+                match conn.send(packet) {
+                    Ok(_) => {
+                        tracing::trace!(
+                            "Pkt -> ConnSock ({:?}), len: {}",
+                            endpoint.addr,
+                            packet.len()
+                        );
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        tracing::debug!(message = "Connected socket send buffer full, dropping packet", error = ?err);
+                    }
+                    Err(err) => {
+                        tracing::debug!(message = "Failed to send packet with the connected socket", error = ?err);
+                        drop(endpoint);
+                        peer.shutdown_endpoint();
+                    }
                 }
             } else if let Some(addr @ SocketAddr::V4(_)) = endpoint.addr {
                 if let Err(err) = udp4.send_to(packet, &addr.into()) {

--- a/neptun/src/device/packet_workers.rs
+++ b/neptun/src/device/packet_workers.rs
@@ -1,0 +1,287 @@
+//! Inter-thread packet processing machinery used on non-Apple platforms.
+//!
+//! On non-Apple targets, packet processing crosses thread boundaries: the
+//! event-loop handlers read packets and dispatch batches through bounded
+//! channels to dedicated worker threads that perform the actual encryption
+//! and write to the network or tunnel. This module owns the channels, the
+//! batch types, and the worker thread bodies.
+//!
+//! Apple targets process packets inline and do not use this module at all.
+
+use std::io::Write;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::thread;
+
+use crossbeam_channel::{Receiver, Sender};
+
+use super::{
+    encapsulate_and_send, read_packet, Action, CheckedMtu, DeviceConfig, IfaceReadResult,
+    MAX_PKT_SIZE, WG_HEADER_OFFSET,
+};
+use crate::device::allowed_ips::AllowedIps;
+use crate::device::peer::Peer;
+use crate::device::tun::TunSocket;
+
+const CHANNEL_SIZE: usize = 500;
+const MAX_INTERTHREAD_BATCHED_PKTS: usize = 50;
+
+pub(super) struct PacketWorkers {
+    pub max_batched_pkts: usize,
+
+    tunnel_to_socket_tx: Sender<Vec<NetworkTaskData>>,
+    tunnel_to_socket_rx: Receiver<Vec<NetworkTaskData>>,
+
+    socket_to_tunnel_tx: Sender<Vec<TunnelWorkerData>>,
+    socket_to_tunnel_rx: Receiver<Vec<TunnelWorkerData>>,
+
+    close_network_worker_tx: Option<Sender<()>>,
+    close_tun_worker_tx: Option<Sender<()>>,
+}
+
+struct NetworkTaskData {
+    data: [u8; MAX_PKT_SIZE],
+    buf_len: usize,
+    peer: Arc<Peer>,
+    iface: Arc<TunSocket>,
+}
+
+pub(super) struct TunnelWorkerData {
+    pub buffer: [u8; MAX_PKT_SIZE],
+    pub peer: Arc<Peer>,
+    pub iface: Arc<TunSocket>,
+    pub addr: IpAddr,
+    pub buf_len: usize,
+}
+
+enum BatchResult {
+    Continue,
+    Exhausted,
+    Fatal,
+}
+
+impl PacketWorkers {
+    pub fn new(config: &DeviceConfig) -> Self {
+        let max_batched_pkts = config
+            .max_inter_thread_batched_pkts
+            .unwrap_or(MAX_INTERTHREAD_BATCHED_PKTS);
+
+        let channel_size = config.inter_thread_channel_size.unwrap_or(CHANNEL_SIZE);
+        let (tunnel_to_socket_tx, tunnel_to_socket_rx) = crossbeam_channel::bounded(channel_size);
+        let (socket_to_tunnel_tx, socket_to_tunnel_rx) = crossbeam_channel::bounded(channel_size);
+
+        Self {
+            max_batched_pkts,
+            tunnel_to_socket_tx,
+            tunnel_to_socket_rx,
+            socket_to_tunnel_tx,
+            socket_to_tunnel_rx,
+            close_network_worker_tx: None,
+            close_tun_worker_tx: None,
+        }
+    }
+
+    pub fn shutdown(&mut self) {
+        if let Some(close_network_worker_tx) = &self.close_network_worker_tx {
+            for _ in 0..num_cpus::get_physical() {
+                if let Err(e) = close_network_worker_tx.try_send(()) {
+                    tracing::error!("Unable to close network thread {e}");
+                }
+            }
+        }
+        if let Some(close_tun_worker_tx) = &self.close_tun_worker_tx {
+            if let Err(e) = close_tun_worker_tx.try_send(()) {
+                tracing::error!("Unable to close tun thread {e}");
+            }
+        }
+    }
+
+    pub fn start(
+        &mut self,
+        udp4: Arc<socket2::Socket>,
+        udp6: Arc<socket2::Socket>,
+        config: &DeviceConfig,
+    ) {
+        // Construct a different closing channel per thread
+        let (close_network_worker_tx, close_network_worker_rx) =
+            crossbeam_channel::bounded(num_cpus::get_physical() * 5);
+        let (close_tun_worker_tx, close_tun_worker_rx) = crossbeam_channel::bounded(5);
+
+        self.close_network_worker_tx = Some(close_network_worker_tx);
+        self.close_tun_worker_tx = Some(close_tun_worker_tx);
+
+        for _ in 0..num_cpus::get_physical() {
+            let tunnel_to_socket_rx = self.tunnel_to_socket_rx.clone();
+            let close_chan_clone = close_network_worker_rx.clone();
+            let udp4_c = udp4.clone();
+            let udp6_c = udp6.clone();
+            let fw_callback = config
+                .firewall_process_outbound_callback
+                .as_ref()
+                .map(|f| f.clone());
+            thread::spawn(move || {
+                write_to_socket_worker(
+                    tunnel_to_socket_rx,
+                    close_chan_clone,
+                    udp4_c,
+                    udp6_c,
+                    fw_callback,
+                )
+            });
+        }
+
+        let socket_to_tunnel_rx = self.socket_to_tunnel_rx.clone();
+        let fw_callback = config.firewall_process_inbound_callback.clone();
+        thread::spawn(move || {
+            write_to_tun_worker(socket_to_tunnel_rx, close_tun_worker_rx, fw_callback)
+        });
+    }
+
+    /// Reads packets from the iface in batches and dispatches each batch to the
+    /// network worker threads via the outbound channel. Returns `Action::Exit`
+    /// only on a fatal iface read error; otherwise drains until the iface
+    /// reports `WouldBlock`/`Interrupted`.
+    pub fn dispatch_iface_read(
+        &self,
+        iface: &Arc<TunSocket>,
+        mtu: &CheckedMtu,
+        peers: &AllowedIps<Arc<Peer>>,
+    ) -> Action {
+        loop {
+            let (batched_pkts, result) = read_iface_batch(iface, mtu, peers, self.max_batched_pkts);
+
+            match result {
+                BatchResult::Fatal => return Action::Exit,
+                BatchResult::Continue | BatchResult::Exhausted => {
+                    if let Err(e) = self.tunnel_to_socket_tx.send(batched_pkts) {
+                        tracing::warn!("Unable to forward data onto network worker {e}");
+                    }
+                    if matches!(result, BatchResult::Exhausted) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Action::Continue
+    }
+
+    /// Submit a batch of decapsulated packets to the inbound worker for
+    /// writing to the tun interface.
+    pub fn submit_inbound(&self, batch: Vec<TunnelWorkerData>) {
+        if let Err(e) = self.socket_to_tunnel_tx.send(batch) {
+            tracing::warn!("Unable to forward data onto tunnel worker {e}");
+        }
+    }
+}
+
+fn read_iface_batch(
+    iface: &Arc<TunSocket>,
+    mtu: &CheckedMtu,
+    peers: &AllowedIps<Arc<Peer>>,
+    max_batched_pkts: usize,
+) -> (Vec<NetworkTaskData>, BatchResult) {
+    let mut batched_pkts = Vec::with_capacity(max_batched_pkts);
+
+    for _ in 0..batched_pkts.capacity() {
+        let mut buffer = [0u8; MAX_PKT_SIZE];
+        match read_packet(iface, &mut buffer, mtu, peers) {
+            IfaceReadResult::Exhausted => return (batched_pkts, BatchResult::Exhausted),
+            IfaceReadResult::Fatal => return (batched_pkts, BatchResult::Fatal),
+            IfaceReadResult::Skip => continue,
+            IfaceReadResult::Packet { payload, peer } => {
+                let len = payload.len();
+                batched_pkts.push(NetworkTaskData {
+                    data: buffer,
+                    buf_len: len,
+                    peer,
+                    iface: iface.clone(),
+                });
+            }
+        }
+    }
+
+    (batched_pkts, BatchResult::Continue)
+}
+
+fn write_to_socket_worker(
+    tunnel_to_socket_rx: Receiver<Vec<NetworkTaskData>>,
+    close_chan: Receiver<()>,
+    udp4: Arc<socket2::Socket>,
+    udp6: Arc<socket2::Socket>,
+    firewall_process_outbound_callback: Option<
+        Arc<dyn Fn(&[u8; 32], &[u8], &mut dyn std::io::Write) -> bool + Send + Sync>,
+    >,
+) {
+    loop {
+        crossbeam_channel::select! {
+            recv(tunnel_to_socket_rx) -> element => {
+                if let Ok(mut batched_pkts) = element {
+                    for element in batched_pkts.iter_mut() {
+                        let len = element.buf_len;
+
+                        if let Some(callback) = &firewall_process_outbound_callback {
+                            let buffer = match element.data.get(WG_HEADER_OFFSET..len + WG_HEADER_OFFSET) {
+                                Some(b) => b,
+                                None => continue,
+                            };
+                            if !callback(&element.peer.public_key.0, buffer, &mut element.iface.as_ref()) {
+                                continue;
+                            }
+                        }
+
+                        encapsulate_and_send(&element.peer, &mut element.data[..], len, &udp4, &udp6);
+                    }
+                }
+            }
+            recv(close_chan) -> _n => {
+                break;
+            }
+        }
+    }
+}
+
+fn write_to_tun_worker(
+    socket_to_tunnel_rx: Receiver<Vec<TunnelWorkerData>>,
+    close_chan: Receiver<()>,
+    firewall_process_inbound_callback: Option<
+        Arc<dyn Fn(&[u8; 32], &mut [u8]) -> bool + Send + Sync>,
+    >,
+) {
+    loop {
+        crossbeam_channel::select! {
+            recv(socket_to_tunnel_rx) -> batched_pkts => {
+                if let Ok(batched_pkts) = batched_pkts {
+                    for mut t in batched_pkts {
+                        let peer = t.peer;
+
+                        let buffer = match t.buffer.get_mut(..t.buf_len) {
+                            Some(b) => b,
+                            None => {
+                                tracing::warn!("Length is greater than buffer space");
+                                continue
+                            },
+                        };
+                        if let Some(callback) = &firewall_process_inbound_callback {
+                            if !callback(&peer.public_key.0, buffer) {
+                                continue;
+                            }
+                        }
+                        if peer.is_allowed_ip(t.addr) {
+                            _ = t.iface.as_ref().write(buffer);
+                            tracing::trace!(
+                                message = "Writing packet to tunnel",
+                                packet_length = t.buf_len,
+                                src_addr = ?t.addr,
+                                public_key = peer.public_key.1
+                            );
+                        }
+                    }
+                }
+            }
+            recv(close_chan) -> _n => {
+                break;
+            }
+        }
+    }
+}

--- a/neptun/src/device/peer.rs
+++ b/neptun/src/device/peer.rs
@@ -9,10 +9,14 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, SocketAddrV4, S
 use std::str::FromStr;
 use std::sync::Arc;
 
-use crate::device::{modify_skt_buffer_size, AllowedIps, Error, MakeExternalNeptun};
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+use crate::device::modify_skt_buffer_size;
+use crate::device::{AllowedIps, Error, MakeExternalNeptun};
 use crate::noise::Tunn;
 
-use std::os::fd::{AsFd, AsRawFd};
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+use std::os::fd::AsFd;
+use std::os::fd::AsRawFd;
 
 #[derive(Default, Debug)]
 pub struct Endpoint {
@@ -114,9 +118,14 @@ impl Peer {
         endpoint.addr = Some(addr);
     }
 
+    /// On Apple platforms, setting `skt_buffer_size` won't have any effect whatsoever.
     pub fn connect_endpoint(
         &self,
         port: u16,
+        #[cfg_attr(
+            any(target_os = "macos", target_os = "ios", target_os = "tvos"),
+            allow(unused_variables)
+        )]
         skt_buffer_size: Option<usize>,
     ) -> Result<socket2::Socket, Error> {
         let mut endpoint = self.endpoint.write();
@@ -157,6 +166,7 @@ impl Peer {
 
         endpoint.conn = Some(udp_conn.try_clone()?);
 
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         if let Some(buffer_size) = skt_buffer_size {
             modify_skt_buffer_size(udp_conn.as_fd(), buffer_size);
         }

--- a/neptun/src/device/peer.rs
+++ b/neptun/src/device/peer.rs
@@ -118,7 +118,8 @@ impl Peer {
         endpoint.addr = Some(addr);
     }
 
-    /// On Apple platforms, setting `skt_buffer_size` won't have any effect whatsoever.
+    /// On Apple platforms, it is optimal to rely on the kernel autotuning of the socket size.
+    /// Hence, setting `skt_buffer_size` won't have any effect for Apple platforms.
     pub fn connect_endpoint(
         &self,
         port: u16,


### PR DESCRIPTION
### Problem
- Current NepTUN implementation shows degraded performance on Apple platforms
- Root cause
  - upload: multiple workers spawned without QoS hints land on mixed P/E cores, causing concurrent batch processing which results in out-of-order packet delivery and TCP congestion control triggering repeated CWND halving
  - download: per-packet heap allocations in the iface handler continuously evict the UDP handler's working set from L1D cache, causing sustained cache-cold decryption throughput reduction

### Solution
- Restore inline, single-threaded iface handler on Apple platforms using thread-local buffers to avoid cache eviction pressure on UDP handler