### PR TITLE
LLT-7323: base64 validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,12 +126,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -936,7 +930,7 @@ name = "neptun"
 version = "2.2.3"
 dependencies = [
  "aead",
- "base64 0.13.1",
+ "base64",
  "blake2",
  "chacha20poly1305",
  "criterion",
@@ -964,6 +958,7 @@ dependencies = [
  "tracing-subscriber",
  "untrusted",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -2175,7 +2170,7 @@ dependencies = [
 name = "xray"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "clap",
  "color-eyre",
  "csv",
@@ -2217,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/neptun/Cargo.toml
+++ b/neptun/Cargo.toml
@@ -19,7 +19,8 @@ mock-instant = ["mock_instant"]
 xray = []
 
 [dependencies]
-base64 = "0.13"
+base64 = "0.22.1"
+zeroize = { version = "1.8.2", features = ["derive"] }
 crossbeam-channel = "0.5.15"
 hex = { version = "0.4" }
 untrusted = "0.9.0"

--- a/neptun/src/device/api.rs
+++ b/neptun/src/device/api.rs
@@ -248,7 +248,7 @@ fn api_set<R: Read>(reader: &mut BufReader<R>, d: &mut LockReadGuard<Device>) ->
                     match key {
                         "private_key" => match val.parse::<KeyBytes>() {
                             Ok(key_bytes) => {
-                                device.set_key(x25519::StaticSecret::from(key_bytes.0))
+                                device.set_key(x25519::StaticSecret::from(*key_bytes.get_bytes()))
                             }
                             Err(_) => return EINVAL,
                         },
@@ -285,7 +285,7 @@ fn api_set<R: Read>(reader: &mut BufReader<R>, d: &mut LockReadGuard<Device>) ->
                                 return api_set_peer(
                                     reader,
                                     device,
-                                    x25519::PublicKey::from(key_bytes.0),
+                                    x25519::PublicKey::from(*key_bytes.get_bytes()),
                                 )
                             }
                             Err(_) => return EINVAL,
@@ -351,7 +351,7 @@ fn api_set_peer<R: Read>(
                     Err(_) => return EINVAL,
                 },
                 "preshared_key" => match val.parse::<KeyBytes>() {
-                    Ok(key_bytes) => preshared_key = Some(key_bytes.0),
+                    Ok(key_bytes) => preshared_key = Some(*key_bytes.get_bytes()),
                     Err(_) => return EINVAL,
                 },
                 "endpoint" => match val.parse::<SocketAddr>() {
@@ -394,7 +394,7 @@ fn api_set_peer<R: Read>(
                     update_only = false; // Reset update only
                     allowed_ips.clear(); //clear the vector content after update
                     match val.parse::<KeyBytes>() {
-                        Ok(key_bytes) => public_key = key_bytes.0.into(),
+                        Ok(key_bytes) => public_key = (*key_bytes.get_bytes()).into(),
                         Err(_) => return EINVAL,
                     }
                 }

--- a/neptun/src/noise/timers.rs
+++ b/neptun/src/noise/timers.rs
@@ -8,6 +8,7 @@ use std::mem;
 use std::ops::{Index, IndexMut};
 use std::time::SystemTime;
 
+use base64::{engine::general_purpose, Engine};
 #[cfg(feature = "mock-instant")]
 use mock_instant::Instant;
 use x25519_dalek::PublicKey;
@@ -47,7 +48,7 @@ const COOKIE_EXPIRATION_TIME: Duration = Duration::from_secs(120);
 // the first and last 4 chars of the key for better diagnostics while
 // not revealing the full key.
 fn format_pubkey_short(&key: &PublicKey) -> String {
-    let encoded = base64::encode(key);
+    let encoded = general_purpose::STANDARD.encode(key);
     if encoded.len() <= 8 {
         encoded
     } else {

--- a/neptun/src/serialization.rs
+++ b/neptun/src/serialization.rs
@@ -35,14 +35,6 @@ impl std::str::FromStr for KeyBytes {
                     .map_err(|_| "Illegal character in key")?;
                 }
             }
-            43 => {
-                // Try to parse as unpadded base64
-                match general_purpose::STANDARD_NO_PAD.decode_slice(s, &mut *internal) {
-                    Ok(len) if len == internal.len() => {}
-                    Ok(_) => return Err("Decoded key has wrong length"),
-                    Err(_) => return Err("Failed to decode base64"),
-                }
-            }
             44 => {
                 // Try to parse as padded base64
                 match general_purpose::STANDARD.decode_slice(s, &mut *internal) {
@@ -176,13 +168,10 @@ mod tests {
     }
 
     #[test]
-    fn unpadded_base64_43_chars_is_accepted() {
+    fn unpadded_base64_43_chars_is_rejected() {
         let unpadded = general_purpose::STANDARD_NO_PAD.encode([0u8; 32]);
         assert_eq!(unpadded.len(), 43);
-
-        let result = KeyBytes::from_str(&unpadded);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().get_bytes(), &[0u8; 32]);
+        assert!(KeyBytes::from_str(&unpadded).is_err());
     }
 
     #[test]

--- a/neptun/src/serialization.rs
+++ b/neptun/src/serialization.rs
@@ -1,12 +1,27 @@
+use base64::{engine::general_purpose, Engine};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+
 #[allow(dead_code)]
-pub(crate) struct KeyBytes(pub [u8; 32]);
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub(crate) struct KeyBytes([u8; 32]);
+
+impl KeyBytes {
+    #[allow(dead_code)]
+    pub(crate) fn get_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
 
 impl std::str::FromStr for KeyBytes {
     type Err = &'static str;
 
     /// Can parse a secret key from a hex or base64 encoded string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut internal = [0u8; 32];
+        if !s.is_ascii() {
+            return Err("Key must be ASCII encoded");
+        }
+
+        let mut internal = Zeroizing::new([0u8; 32]);
 
         match s.len() {
             64 => {
@@ -20,19 +35,163 @@ impl std::str::FromStr for KeyBytes {
                     .map_err(|_| "Illegal character in key")?;
                 }
             }
-            43 | 44 => {
-                // Try to parse as base64
-                if let Ok(decoded_key) = base64::decode(s) {
-                    if decoded_key.len() == internal.len() {
-                        internal[..].copy_from_slice(&decoded_key);
-                    } else {
-                        return Err("Illegal character in key");
-                    }
+            43 => {
+                // Try to parse as unpadded base64
+                match general_purpose::STANDARD_NO_PAD.decode_slice(s, &mut *internal) {
+                    Ok(len) if len == internal.len() => {}
+                    Ok(_) => return Err("Decoded key has wrong length"),
+                    Err(_) => return Err("Failed to decode base64"),
+                }
+            }
+            44 => {
+                // Try to parse as padded base64
+                match general_purpose::STANDARD.decode_slice(s, &mut *internal) {
+                    Ok(len) if len == internal.len() => {}
+                    Ok(_) => return Err("Decoded key has wrong length"),
+                    Err(_) => return Err("Failed to decode base64"),
                 }
             }
             _ => return Err("Illegal key size"),
         }
 
-        Ok(KeyBytes(internal))
+        Ok(KeyBytes(*internal))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn invalid_base64_44_chars_should_return_error() {
+        // 44 chars of garbage — not valid base64
+        let invalid = "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$";
+        assert_eq!(invalid.len(), 44);
+
+        let result = KeyBytes::from_str(invalid);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_base64_43_chars_should_return_error() {
+        // 43 chars of garbage — not valid base64
+        let invalid = "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$";
+        assert_eq!(invalid.len(), 43);
+
+        let result = KeyBytes::from_str(invalid);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn valid_base64_key_should_succeed() {
+        // 32 zero bytes encoded as base64
+        let valid = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        assert_eq!(valid.len(), 44);
+
+        let result = KeyBytes::from_str(valid);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().get_bytes(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn valid_hex_should_succeed() {
+        let hex = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert_eq!(hex.len(), 64);
+        let result = KeyBytes::from_str(hex);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().get_bytes(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn valid_hex_with_nonzero_bytes_should_succeed() {
+        let hex = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+        assert_eq!(hex.len(), 64);
+        let result = KeyBytes::from_str(hex).unwrap();
+        let expected: [u8; 32] = core::array::from_fn(|i| (i + 1) as u8);
+        assert_eq!(result.get_bytes(), &expected);
+    }
+
+    #[test]
+    fn valid_hex_uppercase_should_succeed() {
+        let hex = "0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20";
+        assert_eq!(hex.len(), 64);
+        let result = KeyBytes::from_str(hex).unwrap();
+        let expected: [u8; 32] = core::array::from_fn(|i| (i + 1) as u8);
+        assert_eq!(result.get_bytes(), &expected);
+    }
+
+    #[test]
+    fn valid_hex_mixed_case_should_succeed() {
+        let hex = "0102030405060708090a0B0c0D0e0F101112131415161718191A1b1C1d1E1f20";
+        assert_eq!(hex.len(), 64);
+        let result = KeyBytes::from_str(hex).unwrap();
+        let expected: [u8; 32] = core::array::from_fn(|i| (i + 1) as u8);
+        assert_eq!(result.get_bytes(), &expected);
+    }
+
+    #[test]
+    fn invalid_hex_chars_should_return_error() {
+        let invalid = "z".repeat(64);
+        assert!(KeyBytes::from_str(&invalid).is_err());
+    }
+
+    #[test]
+    fn hex_with_0x_prefix_should_return_error() {
+        let hex = "0x02030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+        assert_eq!(hex.len(), 64);
+        assert!(KeyBytes::from_str(hex).is_err());
+    }
+
+    #[test]
+    fn empty_string_should_return_error() {
+        assert!(KeyBytes::from_str("").is_err());
+    }
+
+    #[test]
+    fn wrong_lengths_should_return_error() {
+        assert!(KeyBytes::from_str("a").is_err());
+        assert!(KeyBytes::from_str(&"a".repeat(42)).is_err());
+        assert!(KeyBytes::from_str(&"a".repeat(45)).is_err());
+        assert!(KeyBytes::from_str(&"a".repeat(63)).is_err());
+        assert!(KeyBytes::from_str(&"a".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn multibyte_utf8_should_return_error() {
+        let s = "ä".repeat(32); // 'ä' is 2 bytes in UTF-8, so 32 × 2 = 64 bytes
+        assert_eq!(s.len(), 64);
+        assert!(KeyBytes::from_str(&s).is_err());
+    }
+
+    #[test]
+    fn base64_decoding_to_wrong_length_should_return_error() {
+        let short_b64 = general_purpose::STANDARD.encode([0u8; 16]);
+        assert!(short_b64.len() == 24);
+        assert!(KeyBytes::from_str(&short_b64).is_err());
+
+        let long_b64 = general_purpose::STANDARD.encode([0u8; 33]);
+        assert_eq!(long_b64.len(), 44);
+        assert!(KeyBytes::from_str(&long_b64).is_err());
+    }
+
+    #[test]
+    fn unpadded_base64_43_chars_is_accepted() {
+        let unpadded = general_purpose::STANDARD_NO_PAD.encode([0u8; 32]);
+        assert_eq!(unpadded.len(), 43);
+
+        let result = KeyBytes::from_str(&unpadded);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().get_bytes(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn padded_base64_44_chars_is_accepted() {
+        let padded = general_purpose::STANDARD.encode([0u8; 32]);
+        assert_eq!(padded.len(), 44);
+
+        let result = KeyBytes::from_str(&padded);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().get_bytes(), &[0u8; 32]);
     }
 }


### PR DESCRIPTION
## Problem
The KeyBytes parser in `serialization.rs` had several security issues and was missing better base64 validation.

## Solution
- Added `base64` validation, updated dependency and removed unnecessary heap allocation.
- Added `zeroize` to ensure key memory is zeroed when dropped.
- Made the inner field private and added a `get_bytes()` function. This ensures `Drop` always runs and that `KeyBytes` can not be constructed directly, bypassing validation.