### PR TITLE
LLT-7475: Fix race in event loop registration with GCD group

### DIFF
--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -1266,11 +1266,12 @@ fn process_iface_inline(
 
 fn read_packet<'a>(
     iface: &Arc<TunSocket>,
-    buf: &'a mut [u8],
+    buf: &'a mut [u8; MAX_PKT_SIZE],
     mtu: &CheckedMtu,
     peers: &AllowedIps<Arc<Peer>>,
 ) -> IfaceReadResult<'a> {
-    #[allow(clippy::indexing_slicing)] // Correct size guaranteed by the CheckedMtu type
+    // buf is [u8; MAX_PKT_SIZE] and CheckedMtu guarantees mtu + WG_HEADER_OFFSET <= MAX_PKT_SIZE
+    #[allow(clippy::indexing_slicing)]
     match iface.read(&mut buf[WG_HEADER_OFFSET..WG_HEADER_OFFSET + mtu.get()]) {
         Ok(payload) => match Tunn::dst_address(payload) {
             None => IfaceReadResult::Skip,

--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -272,12 +272,8 @@ impl DeviceHandle {
                     sockets_to_close
                         .read()
                         .try_writeable(|_| {}, |fds| fds.push(thread_local.iface.clone()));
-                    let group_clone = group.clone();
                     let queue = dispatch::Queue::global(dispatch::QueuePriority::High);
-                    queue.exec_async(move || {
-                        group_clone.enter();
-                        DeviceHandle::event_loop(thread_local, &dev)
-                    });
+                    group.exec_async(&queue, move || DeviceHandle::event_loop(thread_local, &dev));
                     queue
                 });
             }
@@ -335,6 +331,11 @@ impl DeviceHandle {
                 tracing::error!("Unable to gracefully close thread. {:?}", e);
             }
         }
+    }
+
+    #[cfg(all(feature = "docker-tests", target_os = "macos"))]
+    pub fn is_event_loop_active(&self) -> bool {
+        !self.threads.0.is_empty()
     }
 
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]

--- a/neptun/tests/device.rs
+++ b/neptun/tests/device.rs
@@ -386,6 +386,19 @@ fn test_wireguard_get_on_device() {
 }
 
 #[test]
+/// Test that the event loop is registered with the dispatch group on creating DeviceHandle (registration is atomic)
+#[cfg(target_os = "macos")] // specific to dispatch crate's API (Apple's GCD wrapper)
+fn test_event_loop_active_directly_after_device_creation() {
+    let wg = WGHandle::init("192.0.2.0".parse().unwrap(), "::2".parse().unwrap());
+
+    assert!(
+        wg.device.is_event_loop_active(),
+        "Device event loop's dispatch group is empty immediately after `DeviceHandle::new` returned. \
+        A call to `DeviceHandle::wait()` would return instantly."
+    );
+}
+
+#[test]
 #[cfg(not(target_os = "macos"))] // macOS implementation does not support UAPI command chaining within a single connection
 fn test_wireguard_uapi_chaining() {
     let wg = WGHandle::init("192.0.2.0".parse().unwrap(), "::2".parse().unwrap());


### PR DESCRIPTION
### Problem

This PR addresses two separate issues (it is best to review it commit by commit):
- `read_packet` function implementation did not ensure full compile time safety with regard to a buffer indexed access.
- On Apple platforms, there was a race condition in `DeviceHandle::new()` enabling a short time window, during which an immediate call to `DeviceHandle::wait()` resulted in an instant return. This behavior was breaking `neptun-cli` on macOS. 

### Solution

- The type for the `buf` param for `read_packet` function has been updated to harden the compile time check.
- Ensured atomic registration of the event loop through the `Group::exec_async()` call.