### PR TITLE
LLT-6820: Add pubkey info to logs

### DIFF
--- a/neptun/src/device/mod.rs
+++ b/neptun/src/device/mod.rs
@@ -31,6 +31,7 @@ use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::parse_handshake_anon;
 use crate::noise::rate_limiter::RateLimiter;
 use crate::noise::{Packet, Tunn, TunnResult};
+use crate::serialization::PubKey;
 use crate::x25519;
 use allowed_ips::AllowedIps;
 use dev_lock::{Lock, LockReadGuard};
@@ -66,6 +67,18 @@ use {
     std::os::fd::{AsFd, BorrowedFd},
     std::thread::{self, JoinHandle},
 };
+
+/// Entered span carrying a peer's masked id, so every log statement in the
+/// enclosing call inherits a `peer` field.
+///
+/// Accepts anything a [`PubKey`] can be built from - raw bytes, an
+/// `x25519::PublicKey`, or a `PubKey` itself.
+///
+/// `Level::ERROR` makes the span enabled under any filter.
+#[inline]
+pub(crate) fn peer_span(peer: impl Into<PubKey>) -> tracing::span::EnteredSpan {
+    tracing::span!(tracing::Level::ERROR, "tunn", peer = %peer.into()).entered()
+}
 
 const HANDSHAKE_RATE_LIMIT: u64 = 100; // The number of handshakes per second we can tolerate before using cookies
 
@@ -525,6 +538,7 @@ impl Device {
 
     fn remove_peer(&mut self, pub_key: &x25519::PublicKey) {
         if let Some(peer) = self.peers.remove(pub_key) {
+            let _span = peer_span(peer.public_key);
             // Found a peer to remove, now purge all references to it:
             {
                 peer.shutdown_endpoint(); // close open udp socket and free the closure
@@ -600,6 +614,7 @@ impl Device {
         preshared_key: Option<[u8; 32]>,
     ) -> Result<Arc<Peer>, Error> {
         let next_index = self.next_index();
+        let _span = peer_span(pub_key);
         let device_key_pair = self.key_pair.as_ref().ok_or_else(|| {
             tracing::error!("No device keypair specified for a peer");
             Error::InternalError("No device keypair specified for a peer".to_owned())
@@ -888,6 +903,7 @@ impl Device {
 
                 // Go over each peer and invoke the timer function
                 for peer in peer_map.values() {
+                    let _span = peer_span(peer.public_key);
                     let endpoint_addr = match peer.endpoint().addr {
                         Some(addr) => addr,
                         None => continue,
@@ -1028,6 +1044,7 @@ impl Device {
                         None => continue,
                         Some(peer) => peer,
                     };
+                    let _span = peer_span(peer.public_key);
 
                     let mut flush = false; // Are there packets to send from the queue?
                     let res = {
@@ -1048,7 +1065,7 @@ impl Device {
                         }
                         TunnResult::WriteToTunnel(packet, addr) => {
                             if let Some(callback) = &d.config.firewall_process_inbound_callback {
-                                if !callback(&peer.public_key.0, packet) {
+                                if !callback(peer.public_key.as_bytes(), packet) {
                                     continue;
                                 }
                             }
@@ -1059,8 +1076,7 @@ impl Device {
                                     message = "Writing packet to tunnel",
                                     interface = ?t.iface.name(),
                                     packet_length = packet.len(),
-                                    src_addr = ?addr,
-                                    public_key = peer.public_key.1
+                                    src_addr = ?addr
                                 );
                             }
                         }
@@ -1121,6 +1137,7 @@ impl Device {
         self.queue.new_event(
             udp.as_raw_fd(),
             Box::new(move |d, t| {
+                let _span = peer_span(peer.public_key);
                 // The conn_handler handles packet received from a connected UDP socket, associated
                 // with a known peer, this saves us the hustle of finding the right peer. If another
                 // peer gets the same ip, it will be ignored until the socket does not expire.
@@ -1154,13 +1171,11 @@ impl Device {
                                     WireGuardError::DuplicateCounter => {
                                         // TODO(LLT-6071): revert back to having error level for all error types
                                         tracing::debug!(message="Decapsulate error",
-                                            error=?e,
-                                            public_key=peer.public_key.1)
+                                            error=?e)
                                     }
                                     _ => {
                                         tracing::error!(message="Decapsulate error",
-                                        error=?e,
-                                        public_key = peer.public_key.1)
+                                        error=?e)
                                     }
                                 },
                                 TunnResult::WriteToNetwork(packet) => {
@@ -1278,8 +1293,13 @@ fn process_iface_inline(
             IfaceReadResult::Fatal => return Action::Exit,
             IfaceReadResult::Skip => continue,
             IfaceReadResult::Packet { payload, peer } => {
+                let _span = peer_span(peer.public_key);
                 if let Some(callback) = &device.config.firewall_process_outbound_callback {
-                    if !callback(&peer.public_key.0, payload, &mut thread_data.iface.as_ref()) {
+                    if !callback(
+                        peer.public_key.as_bytes(),
+                        payload,
+                        &mut thread_data.iface.as_ref(),
+                    ) {
                         continue;
                     }
                 }
@@ -1341,8 +1361,7 @@ fn encapsulate_and_send(
         TunnResult::Done => {}
         TunnResult::Err(e) => {
             tracing::error!(message = "Encapsulate error",
-                error = ?e,
-                public_key = peer.public_key.1);
+                error = ?e);
         }
         TunnResult::WriteToNetwork(packet) => {
             let endpoint = peer.endpoint();
@@ -1368,13 +1387,13 @@ fn encapsulate_and_send(
                 if let Err(err) = udp4.send_to(packet, &addr.into()) {
                     tracing::warn!(message = "Failed to write packet to network v4", error = ?err, dst = ?addr);
                 } else {
-                    tracing::trace!(message = "Writing packet to network v4", packet_length = packet.len(), src_addr = ?addr, public_key = peer.public_key.1);
+                    tracing::trace!(message = "Writing packet to network v4", packet_length = packet.len(), src_addr = ?addr);
                 }
             } else if let Some(addr @ SocketAddr::V6(_)) = endpoint.addr {
                 if let Err(err) = udp6.send_to(packet, &addr.into()) {
                     tracing::warn!(message = "Failed to write packet to network v6", error = ?err, dst = ?addr);
                 } else {
-                    tracing::trace!(message = "Writing packet to network v6", packet_length = packet.len(), src_addr = ?addr, public_key = peer.public_key.1);
+                    tracing::trace!(message = "Writing packet to network v6", packet_length = packet.len(), src_addr = ?addr);
                 }
             } else {
                 tracing::error!("No endpoint");

--- a/neptun/src/device/packet_workers.rs
+++ b/neptun/src/device/packet_workers.rs
@@ -21,6 +21,7 @@ use super::{
 };
 use crate::device::allowed_ips::AllowedIps;
 use crate::device::peer::Peer;
+use crate::device::peer_span;
 use crate::device::tun::TunSocket;
 
 const CHANNEL_SIZE: usize = 500;
@@ -219,13 +220,14 @@ fn write_to_socket_worker(
                 if let Ok(mut batched_pkts) = element {
                     for element in batched_pkts.iter_mut() {
                         let len = element.buf_len;
+                        let _span = peer_span(element.peer.public_key);
 
                         if let Some(callback) = &firewall_process_outbound_callback {
                             let buffer = match element.data.get_mut(WG_HEADER_OFFSET..len + WG_HEADER_OFFSET) {
                                 Some(b) => b,
                                 None => continue,
                             };
-                            if !callback(&element.peer.public_key.0, buffer, &mut element.iface.as_ref()) {
+                            if !callback(element.peer.public_key.as_bytes(), buffer, &mut element.iface.as_ref()) {
                                 continue;
                             }
                         }
@@ -254,6 +256,7 @@ fn write_to_tun_worker(
                 if let Ok(batched_pkts) = batched_pkts {
                     for mut t in batched_pkts {
                         let peer = t.peer;
+                        let _span = peer_span(peer.public_key);
 
                         let buffer = match t.buffer.get_mut(..t.buf_len) {
                             Some(b) => b,
@@ -263,7 +266,7 @@ fn write_to_tun_worker(
                             },
                         };
                         if let Some(callback) = &firewall_process_inbound_callback {
-                            if !callback(&peer.public_key.0, buffer) {
+                            if !callback(peer.public_key.as_bytes(), buffer) {
                                 continue;
                             }
                         }
@@ -273,7 +276,6 @@ fn write_to_tun_worker(
                                 message = "Writing packet to tunnel",
                                 packet_length = t.buf_len,
                                 src_addr = ?t.addr,
-                                public_key = peer.public_key.1
                             );
                         }
                     }

--- a/neptun/src/device/peer.rs
+++ b/neptun/src/device/peer.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use crate::device::modify_skt_buffer_size;
 use crate::device::{AllowedIps, Error, MakeExternalNeptun};
 use crate::noise::Tunn;
+use crate::serialization::PubKey;
 
 #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
 use std::os::fd::AsFd;
@@ -27,8 +28,9 @@ pub struct Endpoint {
 pub struct Peer {
     /// The associated tunnel struct
     pub(crate) tunnel: Mutex<Tunn>,
-    /// Public key of this peer in raw bytes and hex formats
-    pub(crate) public_key: ([u8; 32], String),
+    /// Public key of this peer. Masked when logged; use `as_bytes()` for the
+    /// raw key material.
+    pub(crate) public_key: PubKey,
     /// The index the tunnel uses
     index: u32,
     endpoint: RwLock<Endpoint>,
@@ -72,15 +74,10 @@ impl Peer {
         protect: Arc<dyn MakeExternalNeptun>,
     ) -> Peer {
         let pub_key = tunnel.peer_static_public();
-        let mut public_key_hex = String::with_capacity(32);
-        for byte in pub_key.as_bytes() {
-            let pub_symbol = format!("{:02X}", byte);
-            public_key_hex.push_str(&pub_symbol);
-        }
 
         Peer {
             tunnel: Mutex::new(tunnel),
-            public_key: (pub_key.to_bytes(), public_key_hex),
+            public_key: PubKey::from(pub_key),
             index,
             endpoint: RwLock::new(Endpoint {
                 addr: endpoint,

--- a/neptun/src/noise/handshake.rs
+++ b/neptun/src/noise/handshake.rs
@@ -5,6 +5,7 @@
 use super::{HandshakeInit, HandshakeResponse, PacketCookieReply};
 use crate::noise::errors::WireGuardError;
 use crate::noise::session::Session;
+use crate::serialization::PubKey;
 #[cfg(not(feature = "mock-instant"))]
 use crate::sleepyinstant::Instant;
 use crate::x25519;
@@ -288,12 +289,13 @@ struct NoiseParams {
 impl std::fmt::Debug for NoiseParams {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("NoiseParams")
-            .field("static_public", &self.static_public)
+            .field("static_public", &PubKey::from(self.static_public))
             .field("static_private", &"<redacted>")
-            .field("peer_static_public", &self.peer_static_public)
+            .field("peer_static_public", &PubKey::from(self.peer_static_public))
             .field("static_shared", &"<redacted>")
             .field("sending_mac1_key", &self.sending_mac1_key)
-            .field("preshared_key", &self.preshared_key)
+            // Secret key material: only whether one is set, never its bytes.
+            .field("preshared_key", &self.preshared_key.map(|_| "<redacted>"))
             .finish()
     }
 }
@@ -358,10 +360,19 @@ struct Cookies {
     write_cookie: Option<[u8; 16]>,
 }
 
-#[derive(Debug)]
 pub struct HalfHandshake {
     pub peer_index: u32,
     pub peer_static_public: [u8; 32],
+}
+
+// Deliberately not derived: a derived Debug would print the whole peer key.
+impl std::fmt::Debug for HalfHandshake {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HalfHandshake")
+            .field("peer_index", &self.peer_index)
+            .field("peer_static_public", &PubKey::from(self.peer_static_public))
+            .finish()
+    }
 }
 
 pub fn parse_handshake_anon(
@@ -867,7 +878,10 @@ impl Handshake {
                 peer_index,
             } => (chaining_key, hash, peer_ephemeral_public, peer_index),
             _ => {
-                tracing::error!("Unexpected attempt to call send_handshake_response");
+                tracing::error!(
+                    peer = %PubKey::from(self.params.peer_static_public),
+                    "Unexpected attempt to call send_handshake_response"
+                );
                 return Err(WireGuardError::UnexpectedPacket);
             }
         };

--- a/neptun/src/noise/timers.rs
+++ b/neptun/src/noise/timers.rs
@@ -8,10 +8,8 @@ use std::mem;
 use std::ops::{Index, IndexMut};
 use std::time::SystemTime;
 
-use base64::{engine::general_purpose, Engine};
 #[cfg(feature = "mock-instant")]
 use mock_instant::thread_local::Instant;
-use x25519_dalek::PublicKey;
 
 #[cfg(not(any(
     feature = "mock-instant",
@@ -43,18 +41,6 @@ pub(crate) const REKEY_ATTEMPT_TIME: Duration = Duration::from_secs(90);
 pub(crate) const REKEY_TIMEOUT: Duration = Duration::from_secs(5);
 const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
 const COOKIE_EXPIRATION_TIME: Duration = Duration::from_secs(120);
-
-// Privacy-aware public key formatter. Aligns with libtelio approach of logging
-// the first and last 4 chars of the key for better diagnostics while
-// not revealing the full key.
-fn format_pubkey_short(&key: &PublicKey) -> String {
-    let encoded = general_purpose::STANDARD.encode(key);
-    if encoded.len() <= 8 {
-        encoded
-    } else {
-        format!("{}...{}", &encoded[..4], &encoded[encoded.len() - 4..])
-    }
-}
 
 #[derive(Debug)]
 pub enum TimerName {
@@ -205,7 +191,6 @@ impl Tunn {
                 if let Some(session) = self.sessions[i].take() {
                     tracing::info!(
                         message = "SESSION_EXPIRED(REJECT_AFTER_TIME)",
-                        peer = format_pubkey_short(&self.peer_static_public),
                         session = session.receiving_index
                     );
                 }
@@ -255,10 +240,7 @@ impl Tunn {
             // All ephemeral private keys and symmetric session keys are zeroed out after
             // (REJECT_AFTER_TIME * 3) ms if no new keys have been exchanged.
             if now - session_established >= REJECT_AFTER_TIME * 3 {
-                tracing::info!(
-                    message = "CONNECTION_EXPIRED(REJECT_AFTER_TIME * 3)",
-                    peer = format_pubkey_short(&self.peer_static_public)
-                );
+                tracing::info!(message = "CONNECTION_EXPIRED(REJECT_AFTER_TIME * 3)",);
                 self.clear_all();
 
                 if persistent_keepalive > 0 {
@@ -279,7 +261,6 @@ impl Tunn {
                     tracing::info!(
                         message = "CONNECTION_EXPIRED
                         (REKEY_ATTEMPT_TIME)",
-                        peer = format_pubkey_short(&self.peer_static_public)
                     );
                     self.clear_all();
 
@@ -297,10 +278,7 @@ impl Tunn {
                     // A handshake initiation is retried after REKEY_TIMEOUT + jitter ms,
                     // if a response has not been received, where jitter is some random
                     // value between 0 and 333 ms.
-                    tracing::debug!(
-                        message = "HANDSHAKE(REKEY_TIMEOUT)",
-                        peer = format_pubkey_short(&self.peer_static_public)
-                    );
+                    tracing::debug!(message = "HANDSHAKE(REKEY_TIMEOUT)",);
                     handshake_initiation_required = true;
                 }
             } else {
@@ -313,10 +291,7 @@ impl Tunn {
                     if session_established < data_packet_sent
                         && now - session_established >= REKEY_AFTER_TIME
                     {
-                        tracing::debug!(
-                            message = "HANDSHAKE(REKEY_AFTER_TIME (on send))",
-                            peer = format_pubkey_short(&self.peer_static_public)
-                        );
+                        tracing::debug!(message = "HANDSHAKE(REKEY_AFTER_TIME (on send))",);
                         handshake_initiation_required = true;
                     }
 
@@ -332,7 +307,6 @@ impl Tunn {
                             message = "HANDSHAKE(REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - \
                         REKEY_TIMEOUT \
                         (on receive))",
-                            peer = format_pubkey_short(&self.peer_static_public)
                         );
                         handshake_initiation_required = true;
                     }
@@ -349,10 +323,7 @@ impl Tunn {
                     })
                     .unwrap_or_default()
                 {
-                    tracing::debug!(
-                        message = "HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)",
-                        peer = format_pubkey_short(&self.peer_static_public)
-                    );
+                    tracing::debug!(message = "HANDSHAKE(KEEPALIVE + REKEY_TIMEOUT)",);
                     handshake_initiation_required = true;
                     self.timers.want_handshake_since = None;
                 }
@@ -364,10 +335,7 @@ impl Tunn {
                         && now - aut_packet_sent >= KEEPALIVE_TIMEOUT
                         && mem::replace(&mut self.timers.want_keepalive, false)
                     {
-                        tracing::debug!(
-                            message = "KEEPALIVE(KEEPALIVE_TIMEOUT)",
-                            peer = format_pubkey_short(&self.peer_static_public)
-                        );
+                        tracing::debug!(message = "KEEPALIVE(KEEPALIVE_TIMEOUT)",);
                         keepalive_required = true;
                     }
 
@@ -377,10 +345,7 @@ impl Tunn {
                             >= Duration::from_secs(persistent_keepalive as _))
                             || self.time_since_last_handshake().is_none())
                     {
-                        tracing::debug!(
-                            message = "KEEPALIVE(PERSISTENT_KEEPALIVE)",
-                            peer = format_pubkey_short(&self.peer_static_public)
-                        );
+                        tracing::debug!(message = "KEEPALIVE(PERSISTENT_KEEPALIVE)",);
                         self.timer_tick(TimePersistentKeepalive);
                         keepalive_required = true;
                     }
@@ -435,17 +400,5 @@ impl Tunn {
 
     pub fn set_persistent_keepalive(&mut self, keepalive: u16) {
         self.timers.persistent_keepalive = keepalive as usize;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::format_pubkey_short;
-    use x25519_dalek::PublicKey;
-
-    #[test]
-    fn test_pubkey_format() {
-        let key = PublicKey::from([1u8; 32]);
-        assert_eq!(format_pubkey_short(&key), "AQEB...AQE=");
     }
 }

--- a/neptun/src/serialization.rs
+++ b/neptun/src/serialization.rs
@@ -1,6 +1,69 @@
 use base64::{engine::general_purpose, Engine};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
+/// Number of leading/trailing base64 characters kept when masking a public key.
+const MASK_KEEP: usize = 4;
+/// base64 length of a 32 byte key: `4 * ceil(32 / 3)`.
+const KEY_BASE64_LEN: usize = 44;
+
+/// Masked public key wrapper.
+///
+/// `Display` and `Debug` both render only the first and last four base64
+/// characters (`AQEB...AQE=`) — enough to tell which peer a log line belongs
+/// to, without putting a whole key in a log sink.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct PubKey([u8; 32]);
+
+impl PubKey {
+    /// Raw key material.
+    // Only used by the firewall callbacks; gated to match `device` in lib.rs,
+    // which is unix-only - otherwise this is dead code on Windows.
+    #[cfg(all(unix, feature = "device"))]
+    pub(crate) const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for PubKey {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<crate::x25519::PublicKey> for PubKey {
+    fn from(key: crate::x25519::PublicKey) -> Self {
+        Self(key.to_bytes())
+    }
+}
+
+impl From<&crate::x25519::PublicKey> for PubKey {
+    fn from(key: &crate::x25519::PublicKey) -> Self {
+        Self(key.to_bytes())
+    }
+}
+
+impl std::fmt::Display for PubKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let encoded = general_purpose::STANDARD.encode(self.0);
+        match (
+            encoded.get(..MASK_KEEP),
+            encoded.get(KEY_BASE64_LEN - MASK_KEEP..),
+        ) {
+            (Some(head), Some(tail)) => write!(f, "{}...{}", head, tail),
+            _ => f.write_str("<unencodable key>"),
+        }
+    }
+}
+
+// Deliberately not derived: a derived Debug would print the raw bytes, and
+// `?key` in a log statement is an easy mistake to make. Debug == Display, so
+// both sigils are safe.
+impl std::fmt::Debug for PubKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Zeroize, ZeroizeOnDrop)]
 pub(crate) struct KeyBytes([u8; 32]);
@@ -54,6 +117,29 @@ impl std::str::FromStr for KeyBytes {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    #[test]
+    fn pubkey_display_is_masked() {
+        // Known keys and the exact fragment each must render as. The full
+        // base64 is spelled out so the expected head and tail can be checked
+        // by eye:
+        //
+        //   [1u8; 32]   AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=
+        //   1..=32      AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=
+        //   [0xff; 32]  //////////////////////////////////////////8=
+        //
+        // The sequential key has a head and tail that differ, so it cannot
+        // pass by coincidence; the all-ones key covers the `/` end of the
+        // base64 alphabet.
+        let sequential: [u8; 32] = core::array::from_fn(|i| (i + 1) as u8);
+
+        assert_eq!(PubKey::from([1u8; 32]).to_string(), "AQEB...AQE=");
+        assert_eq!(PubKey::from(sequential).to_string(), "AQID...HyA=");
+        assert_eq!(PubKey::from([0xffu8; 32]).to_string(), "////...//8=");
+
+        // Debug is masked too, so `?key` is as safe as `%key`.
+        assert_eq!(format!("{:?}", PubKey::from(sequential)), "AQID...HyA=");
+    }
 
     #[test]
     fn invalid_base64_44_chars_should_return_error() {


### PR DESCRIPTION
# Problem

Currently it's hard to match neptun logs with a peer because there is no peer info attached

# Solution

Add peer field to tracing logs with masked public key